### PR TITLE
#26 - Feat - migrate manager page with the new admins flow

### DIFF
--- a/app/core/components/ConfirmationModal/index.tsx
+++ b/app/core/components/ConfirmationModal/index.tsx
@@ -1,0 +1,44 @@
+import React from "react"
+import ModalBox from "../ModalBox"
+import { Button } from "@mui/material"
+import styled from "@emotion/styled"
+
+interface IProps {
+  children: React.ReactNode
+  open: boolean
+  handleClose: React.MouseEventHandler
+  close: Function
+  label: string
+  onClick: React.MouseEventHandler
+  disabled?: boolean | false
+  className?: string | ""
+}
+
+export const Action = styled.div`
+  display: flex;
+  justify-content: flex-end;
+`
+
+export const ConfirmationModal = ({ children, ...props }: IProps) => {
+  return (
+    <ModalBox open={props.open} close={props.close} handleClose={props.handleClose}>
+      {children}
+      <br />
+      <Action>
+        <Button className="primary default" onClick={props.handleClose}>
+          Cancel
+        </Button>
+        &nbsp;
+        <Button
+          className={`primary ${props.className}`}
+          disabled={props.disabled}
+          onClick={props.onClick}
+        >
+          {props.label}
+        </Button>
+      </Action>
+    </ModalBox>
+  )
+}
+
+export default ConfirmationModal

--- a/app/core/components/DropDownButton/DropDownButton.styles.tsx
+++ b/app/core/components/DropDownButton/DropDownButton.styles.tsx
@@ -1,7 +1,17 @@
 import styled from "@emotion/styled"
+import { Link } from "@remix-run/react"
 
 export const DropdownPlaceholderContainer = styled.div`
   display: flex;
   cursor: pointer;
   color: ;
+`
+
+export const DropDownLink = styled(Link)`
+  text-decoration: none;
+
+  :visited {
+    text-decoration: none;
+    color: black;
+  }
 `

--- a/app/core/components/DropDownButton/index.tsx
+++ b/app/core/components/DropDownButton/index.tsx
@@ -1,14 +1,14 @@
 import React, { useEffect, useRef, useState } from "react"
 import { ClickAwayListener, Grow, Paper, Popper, MenuItem, MenuList } from "@mui/material"
 import ExpandMoreIcon from "@mui/icons-material/ExpandMore"
-import { Link } from "@remix-run/react"
 
-import { DropdownPlaceholderContainer } from "./DropDownButton.styles"
+import { DropdownPlaceholderContainer, DropDownLink } from "./DropDownButton.styles"
 
 type DropDownOption = {
-  [x: string]: any;
-  onClick: any;
-  text: any
+  [x: string]: any
+  onClick?: () => void
+  text: string
+  to: string
 }
 
 export const DropDownButton = ({ children, options }: {children: React.ReactNode, options: DropDownOption[] }) => {
@@ -69,23 +69,19 @@ export const DropDownButton = ({ children, options }: {children: React.ReactNode
                 <ClickAwayListener onClickAway={handleClose}>
                   <MenuList id="menu-list-grow" onKeyDown={handleListKeyDown}>
                     {options.map((option, index) => {
-                      const { onClick, text, ...otherOption } = option
+                      const { onClick, text, to, ...otherOption } = option
                       return (
                         <MenuItem
                           {...otherOption}
                           onClick={(e: any) => {
                             handleClose(e)
-                            onClick()
+                            onClick && onClick()
                           }}
-                          component={btnProps => (
-                            // eslint-disable-next-line jsx-a11y/anchor-has-content
-                            <Link to='new'
-                              {...btnProps as any}
-                            />
-                          )}
                           key={index}
                         >
-                          {text}
+                          <DropDownLink to={to}>
+                            {text}
+                          </DropDownLink>
                         </MenuItem>
                       )
                     })}

--- a/app/core/components/ModalBox/index.tsx
+++ b/app/core/components/ModalBox/index.tsx
@@ -1,0 +1,57 @@
+import React from "react"
+import { Modal, Box, IconButton } from "@mui/material"
+import styled from "@emotion/styled"
+import { Close as CloseIcon } from "@mui/icons-material"
+
+export const BoxContainer = styled.div`
+  width: 500px;
+  margin: 0 auto;
+  background: #fff;
+  padding: 10px;
+  border-radius: 4px;
+`
+
+export const ModalContainer = styled.div`
+  display: flex;
+  align-items: center;
+  height: 100%;
+`
+
+export const Action = styled.div`
+  display: flex;
+  justify-content: flex-end;
+`
+
+interface IProps {
+  children: React.ReactNode
+  open: boolean
+  handleClose: React.MouseEventHandler
+  close: Function
+  boxStyle?: React.CSSProperties
+}
+
+export const ModalBox = ({ children, boxStyle, ...props }: IProps) => {
+  return (
+    <Modal
+      open={props.open}
+      onClose={props.handleClose}
+      aria-labelledby="modal-modal-title"
+      aria-describedby="modal-modal-description"
+    >
+      <ModalContainer>
+        <BoxContainer style={boxStyle}>
+          <Box sx={{ marginTop: "0px" }}>
+            <Action>
+              <IconButton onClick={() => props.close()}>
+                <CloseIcon />
+              </IconButton>
+            </Action>
+            {children}
+          </Box>
+        </BoxContainer>
+      </ModalContainer>
+    </Modal>
+  )
+}
+
+export default ModalBox

--- a/app/core/components/ProposalCard/ProposalCard.styles.tsx
+++ b/app/core/components/ProposalCard/ProposalCard.styles.tsx
@@ -1,4 +1,5 @@
 import styled from "@emotion/styled"
+import { Link } from '@remix-run/react'
 
 export const ProposalCardWrap = styled.div`
   display: flex;
@@ -146,3 +147,8 @@ export const ProposalCardWrap = styled.div`
     color: #000000;
   }
 `
+
+export const ProposalCardLink = styled(Link)`
+    text-decoration: none;
+`
+

--- a/app/core/components/ProposalCard/index.tsx
+++ b/app/core/components/ProposalCard/index.tsx
@@ -1,4 +1,3 @@
-import { Link } from "@remix-run/react"
 import { CardActionArea, CardContent, Card } from "@mui/material"
 import EllipsisText from "app/core/components/EllipsisText"
 import ThumbUpIcon from "@mui/icons-material/ThumbUp"
@@ -6,7 +5,7 @@ import PersonIcon from "@mui/icons-material/Person"
 import HelpIcon from "@mui/icons-material/Help"
 
 
-import { ProposalCardWrap } from "./ProposalCard.styles"
+import { ProposalCardWrap, ProposalCardLink } from "./ProposalCard.styles"
 
 interface IProps {
   id: string | number
@@ -38,8 +37,8 @@ export const ProposalCard = (props: IProps) => {
         }}
       >
         <CardActionArea style={{ height: "100%" }}>
-          <Link to={`/projects/${props.id}`}>
-            <CardContent style={{ backgroundColor: "#FFF", height: "100%" }}>
+          <ProposalCardLink to={`/projects/${props.id}`}>
+            <CardContent style={{ backgroundColor: "#FFF", height: "100%", textDecoration: "none" }}>
               <ProposalCardWrap>
                 <div className="ProposalCard__head">
                   <div className="ProposalCard__head__icon">
@@ -111,7 +110,7 @@ export const ProposalCard = (props: IProps) => {
                 </div>
               </ProposalCardWrap>
             </CardContent>
-          </Link>
+          </ProposalCardLink>
         </CardActionArea>
       </Card>
     </>

--- a/app/core/layouts/Header.tsx
+++ b/app/core/layouts/Header.tsx
@@ -1,6 +1,6 @@
 import styled from "@emotion/styled"
 
-import { useSubmit, useNavigate } from "@remix-run/react";
+import { Link, useSubmit } from "@remix-run/react";
 import { useUser } from "~/utils";
 import DropDownButton from "../components/DropDownButton"
 import Search from "../components/Search"
@@ -10,65 +10,44 @@ interface IProps {
   title: String
 }
 export interface MenuItemArgs {
-  permissions: boolean | undefined
   text: string
-  testId?: string
-  onClick: (props: unknown) => void
+  "data-testid"?: string
+  onClick?: () => void
+  to: string
 }
 
 const Header = ({ title }: IProps) => {
-  const navigate = useNavigate()
   const currentUser = useUser()
   const submit = useSubmit()
 
-  const goHome = () => {
-    navigate("/")
-  }
-  const goManager = () => {
-    navigate("/manager")
-  }
   const options: MenuItemArgs[] =
-    currentUser?.role === "ADMIN"
-      ? [
-          {
-            permissions: true,
-            onClick: async () => {
-              submit(null, { method: "post", action: "/logout" })
-            },
-            text: "Sign out",
-            testId: "sign-out-button",
-          },
-          {
-            permissions: true,
-            onClick: async () => {
-              goManager()
-            },
-            text: "Manager",
-            testId: "go-to-admin",
-          },
-        ]
-      : [
-          {
-            permissions: true,
-            onClick: async () => {
-              submit(null, { method: "post", action: "/logout" })
-            },
-            text: "Sign out",
-            testId: "sign-out-button",
-          },
-        ]
+    [
+      {
+        onClick: async () => {
+          submit(null, { method: "post", action: "/logout" })
+        },
+        to: '/',
+        text: "Sign out",
+        "data-testid": "sign-out-button",
+      },
+      ...(currentUser?.role === "ADMIN" ? [{
+        to: '/manager',
+        text: "Manager",
+        "data-testid": "go-to-admin",
+      }] : []),
+    ]
 
   return (
     <>
       <Wrapper>
         <header>
           <div className="content">
-            <div className="logo" onClick={goHome}>
+            <Link className="logo" to="/">
               <div className="logo--img">
                 <img src="/wizeline.png" alt="wizeline" height={30} width={50} />
               </div>
               <div className="logo--text">Wizelabs</div>
-            </div>
+            </Link>
             <div className="actions--container">
               <Search />
               <div className="actions--container__button">
@@ -111,6 +90,7 @@ const Wrapper = styled.div`
     width: 200px;
     cursor: pointer;
     margin-left: 20px;
+    text-decoration: none;
   }
   .logo--img {
     margin-right: 7px;

--- a/app/core/utils/constants.ts
+++ b/app/core/utils/constants.ts
@@ -1,1 +1,0 @@
-export const adminRoleName = "ADMIN"

--- a/app/core/utils/constants.ts
+++ b/app/core/utils/constants.ts
@@ -1,0 +1,1 @@
+export const adminRoleName = "ADMIN"

--- a/app/core/utils/themeWize.ts
+++ b/app/core/utils/themeWize.ts
@@ -1,0 +1,23 @@
+import { createTheme } from "@mui/material/styles"
+const themeWize = createTheme({
+  palette: {
+    primary: {
+      main: "#E94D44",
+    },
+    secondary: { main: "#3B72A4" },
+    secondaryB: { main: "#00A7E5" },
+    secondaryC: { main: "#E5C8A6" },
+  },
+})
+declare module "@mui/material/styles" {
+  interface Palette {
+    secondaryB: Palette["primary"]
+    secondaryC: Palette["primary"]
+  }
+
+  interface PaletteOptions {
+    secondaryB?: PaletteOptions["primary"]
+    secondaryC?: PaletteOptions["primary"]
+  }
+}
+export default themeWize

--- a/app/models/user.server.ts
+++ b/app/models/user.server.ts
@@ -12,14 +12,56 @@ export async function getUserByEmail(email: User["email"]) {
   return prisma.user.findUnique({ where: { email } });
 }
 
-export async function findOrCreate(create: {email: User["email"], name: User["name"]}) {
+export async function findOrCreate(create: {
+  email: User["email"];
+  name: User["name"];
+}) {
   return prisma.user.upsert({
     where: { email: create.email },
     create,
     update: create,
-  })
+  });
 }
 
 export async function deleteUserByEmail(email: User["email"]) {
   return prisma.user.delete({ where: { email } });
+}
+
+export async function getAdminUsers() {
+  const users = await prisma.user.findMany({
+    where: { role: "ADMIN" },
+    orderBy: { name: "asc" },
+    select: { id: true, name: true, email: true, role: true },
+  });
+
+  return users;
+}
+
+export async function addAdminUser({ email }: { email: string }) {
+  const profileUser = await prisma.profiles.findFirst({ where: { email } });
+  if (!profileUser) {
+    return {error: "User not found in WOS"}
+  }
+  try{
+    const user = await prisma.user.upsert({
+      where: { email },
+      create: {
+        email,
+        role: "ADMIN",
+      },
+      update: { email, role: "ADMIN" },
+    });
+    return {user, error: ""};
+  } catch (e) {
+    throw new Error(JSON.stringify(e))
+  }
+}
+
+export async function removeAdminUser({ id }: { id: string }) {
+  try{
+    await prisma.user.update({ where: { id }, data: { role: "USER" } })
+    return { error: ""};
+  } catch (e) {
+    throw new Error(JSON.stringify(e))
+  }
 }

--- a/app/routes/manager.tsx
+++ b/app/routes/manager.tsx
@@ -1,0 +1,86 @@
+import Header from "app/core/layouts/Header";
+import CardBox from "app/core/components/CardBox";
+import { useState } from "react";
+import { useLoaderData, Outlet } from "@remix-run/react";
+import { redirect } from "@remix-run/server-runtime";
+import type { LoaderFunction } from "@remix-run/node";
+import { json } from "@remix-run/node";
+import {
+  EditPanelsStyles,
+  NavBarTabsStyles,
+  LinkStyles,
+} from "./manager/manager.styles";
+
+import Wrapper from "./projects/projects.styles";
+import { adminRoleName } from "app/core/utils/constants";
+import { requireUser } from "~/session.server";
+
+type LoaderData = {
+  isAdmin: boolean;
+  initialTabIdx: number;
+  initialTitle: string;
+};
+
+export const loader: LoaderFunction = async ({ request }) => {
+  const user = await requireUser(request);
+  const isAdmin = user.role == adminRoleName;
+  console.log(request);
+  const initialTabIdx = request.url.includes("admins") ? 1 : 0;
+  const initialTitle = request.url.includes("admins")
+    ? "Admins"
+    : "Filter Tags";
+  return json<LoaderData>({
+    isAdmin,
+    initialTabIdx,
+    initialTitle,
+  });
+};
+
+export default function ManagerPage() {
+  const { isAdmin, initialTabIdx, initialTitle } =
+    useLoaderData() as LoaderData;
+  const [tabIndex, setTabIndex] = useState(initialTabIdx);
+  const [tabTitle, setTabTitle] = useState(initialTitle);
+
+  if (!isAdmin) return redirect("/");
+
+  const handleChangeTab = (num: number, title: string) => {
+    setTabIndex(num);
+    setTabTitle(title);
+  };
+
+  return (
+    <div>
+      <Header title="Manager" />
+      <Wrapper className="homeWrapper">
+        <NavBarTabsStyles>
+          <EditPanelsStyles>
+            <LinkStyles
+              to="/manager"
+              onClick={() => handleChangeTab(0, "Filter Tags")}
+              className={tabIndex === 0 ? "tabSelected" : undefined}
+            >
+              Filter Tags
+            </LinkStyles>
+            <LinkStyles
+              to="/manager/admins"
+              onClick={() => handleChangeTab(1, "Admins")}
+              className={tabIndex === 1 ? "tabSelected" : undefined}
+            >
+              Admins
+            </LinkStyles>
+          </EditPanelsStyles>
+        </NavBarTabsStyles>
+        <CardBox title={tabTitle}>
+          <Outlet />
+        </CardBox>
+      </Wrapper>
+    </div>
+  );
+}
+
+export function ErrorBoundary({ error }: { error: Error }) {
+  console.error(error);
+
+  return <div>An unexpected error occurred: {error.message}</div>;
+}

--- a/app/routes/manager.tsx
+++ b/app/routes/manager.tsx
@@ -12,7 +12,7 @@ import {
 } from "./manager/manager.styles";
 
 import Wrapper from "./projects/projects.styles";
-import { adminRoleName } from "app/core/utils/constants";
+import { adminRoleName } from "app/constants";
 import { requireUser } from "~/session.server";
 
 type LoaderData = {
@@ -24,7 +24,6 @@ type LoaderData = {
 export const loader: LoaderFunction = async ({ request }) => {
   const user = await requireUser(request);
   const isAdmin = user.role == adminRoleName;
-  console.log(request);
   const initialTabIdx = request.url.includes("admins") ? 1 : 0;
   const initialTitle = request.url.includes("admins")
     ? "Admins"

--- a/app/routes/manager/admins.tsx
+++ b/app/routes/manager/admins.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect } from "react";
 import { useFetcher, useLoaderData, useCatch } from "@remix-run/react";
-import type { LoaderFunction, ActionFunction } from "@remix-run/node";
+import type { LoaderFunction, ActionFunction, MetaFunction } from "@remix-run/node";
 import { json } from "@remix-run/node";
 import { DataGrid, GridToolbarContainer } from "@mui/x-data-grid";
 import { ThemeProvider } from "@mui/material/styles";
@@ -39,6 +39,14 @@ export const loader: LoaderFunction = async () => {
   return json<LoaderData>({
     admins,
   });
+};
+
+export const meta: MetaFunction = () => {
+  return {
+    title: "Wizelabs - Admins",
+    description:
+      "This is the Manager's Admin Tab",
+  };
 };
 
 export const action: ActionFunction = async ({ request }) => {

--- a/app/routes/manager/admins.tsx
+++ b/app/routes/manager/admins.tsx
@@ -108,13 +108,12 @@ export default function  AdminsDataGrid() {
   const { admins } = useLoaderData();
   const [error, setError] = useState<string>("");
   const createButtonText = "Add New Admin";
-  // const [removeAdminRoleMutation] = useMutation(removeAdminRole);
   const [rows, setRows] = useState<AdminRecord[]>(() =>
     admins ? admins.map((item: AdminRecord) => ({
-      id: item.id,
-      name: item.name,
-      email: item.email,
-    }))
+        id: item.id,
+        name: item.name,
+        email: item.email,
+      }))
     : []
   );
 

--- a/app/routes/manager/admins.tsx
+++ b/app/routes/manager/admins.tsx
@@ -1,0 +1,352 @@
+import React, { useState, useEffect } from "react";
+import { useFetcher, useLoaderData, useCatch } from "@remix-run/react";
+import type { LoaderFunction, ActionFunction } from "@remix-run/node";
+import { json } from "@remix-run/node";
+import { DataGrid, GridToolbarContainer } from "@mui/x-data-grid";
+import { ThemeProvider } from "@mui/material/styles";
+import Button from "@mui/material/Button";
+import AddIcon from "@mui/icons-material/Add";
+import DeleteIcon from "@mui/icons-material/DeleteOutlined";
+import SaveIcon from "@mui/icons-material/Save";
+import CancelIcon from "@mui/icons-material/Close";
+import invariant from "tiny-invariant";
+
+import themeWize from "app/core/utils/themeWize";
+import ConfirmationModal from "../../core/components/ConfirmationModal";
+import { getAdminUsers, addAdminUser, removeAdminUser } from "~/models/user.server";
+
+type LoaderData = {
+  admins: Awaited<ReturnType<typeof getAdminUsers>>;
+};
+
+type AdminRecord = {
+  id: number | string;
+  name: string | null;
+  email: string;
+};
+
+type gridEditToolbarProps = {
+  setRows: React.Dispatch<React.SetStateAction<AdminRecord[]>>;
+  createButtonText: string;
+};
+
+type newAdmin = {
+  email: string;
+};
+
+export const loader: LoaderFunction = async () => {
+  const admins = await getAdminUsers();
+  return json<LoaderData>({
+    admins,
+  });
+};
+
+export const action: ActionFunction = async ({ request }) => {
+  const formData = await request.formData()
+
+  const action = formData.get('action')
+  let response
+
+  switch (action) {
+    case 'POST':
+      const email = formData.get("email") as string
+      invariant(email, 'Invalid email address')
+      response = await addAdminUser({email})
+      if (response.error) {
+        return json({error: response.error}, {status: 404})
+      }
+      return json(response, {status: 201})
+    
+    case 'DELETE':
+      const id = formData.get("id") as string
+      invariant(id, "User Id is required")
+      response = await removeAdminUser({id})
+      if (response.error) {
+        return json({error: response.error}, {status: 400})
+      }
+      return json(response, {status: 200})
+
+    default: {
+      throw new Error("Something went wrong");
+    }
+  }
+};
+
+const GridEditToolbar = (props: gridEditToolbarProps) => {
+  const { setRows, createButtonText } = props;
+
+  const handleAddClick = () => {
+    const id = "new-value";
+    const newName = "";
+    const newEmail = "";
+    setRows((prevRows) => {
+      if (prevRows.find((rowValue) => rowValue.id === "new-value")) {
+        return [...prevRows];
+      }
+      return [
+        ...prevRows,
+        { id, name: newName, email: newEmail, isNew: true },
+      ] as AdminRecord[];
+    });
+  };
+  return (
+    <GridToolbarContainer>
+      <Button
+        variant="contained"
+        color="primary"
+        startIcon={<AddIcon />}
+        onClick={() => handleAddClick()}
+      >
+        {createButtonText}
+      </Button>
+    </GridToolbarContainer>
+  );
+};
+
+export default function  AdminsDataGrid() {
+  const fetcher = useFetcher();
+  const { admins } = useLoaderData();
+  const [error, setError] = useState<string>("");
+  const createButtonText = "Add New Admin";
+  // const [removeAdminRoleMutation] = useMutation(removeAdminRole);
+  const [rows, setRows] = useState<AdminRecord[]>(() =>
+    admins ? admins.map((item: AdminRecord) => ({
+      id: item.id,
+      name: item.name,
+      email: item.email,
+    }))
+    : []
+  );
+
+  // handle Delete Admin variables
+  const [selectedRowID, setSelectedRowID] = useState("");
+  const [openDeleteModal, setOpenDeleteModal] = useState<boolean>(false);
+
+  useEffect(() =>{
+    //It handles the fetcher error from the response
+    if (fetcher.state === "idle" && fetcher.data) {
+      if (fetcher.data.error){
+        setError(fetcher.data.error);
+      } else {
+        setError("")
+      }
+    }
+  }, [fetcher])
+
+  useEffect(()=> {
+    //It changes the rows shown based on admins
+    setRows(admins.map((item: AdminRecord) => ({
+      id: item.id,
+      name: item.name,
+      email: item.email,
+    })))
+  }, [admins])
+
+  // Set handles for interactions
+  const handleRowEditStart = (event: any) => {
+    event.defaultMuiPrevented = true;
+  };
+
+  const handleRowEditStop = (event: any) => {
+    event.defaultMuiPrevented = true;
+  };
+
+  const handleCellFocusOut = (event: any) => {
+    event.defaultMuiPrevented = true;
+  };
+
+  //Add new Admin
+  const addNewAdminUser = async (values: newAdmin) => {
+    try {
+      const body = {
+        ...values,
+        action: 'POST'
+      }
+      await fetcher.submit(body, { method: "post" });
+    } catch (error: any) {
+      console.error(error);
+      setError(error.toString());
+    }
+  };
+
+  const handleCancelClick = async (idRef: any) => {
+    const id = idRef.row.id;
+    idRef.api.setRowMode(id, "view");
+
+    const row = idRef.api.getRow(id);
+    if (row && row.isNew) {
+      await idRef.api.updateRows([{ id, _action: "delete" }]);
+      setRows((prevRows) => {
+        const rowToDeleteIndex = prevRows.length - 1;
+        return [
+          ...rows.slice(0, rowToDeleteIndex),
+          ...rows.slice(rowToDeleteIndex + 1),
+        ];
+      });
+    }
+    setError("");
+  };
+
+  const handleSaveClick = async (idRef: any) => {
+    const id = idRef.row.id;
+
+    const row = idRef.api.getRow(id);
+    const isValid = await idRef.api.commitRowChange(idRef.row.id);
+    const newEmail = idRef.api.getCellValue(id, "email");
+
+    if (rows.find((rowValue) => rowValue.email === newEmail)) {
+      console.error("Field Already exists");
+      setError("Error: User is already an admin");
+      return;
+    } else {
+      console.error("All fields are valid");
+    }
+
+    if (row.isNew && isValid) {
+      const newValues = { email: newEmail };
+      idRef.api.setRowMode(id, "view");
+      addNewAdminUser(newValues);
+      setRows(prevRows => prevRows.filter(row => row.id !== "new-value"))
+      return;
+    }
+  };
+  
+  //Delete Admin
+  const deleteConfirmationHandler = async () => {
+    setOpenDeleteModal(false);
+    try {
+      const body = {
+        id: selectedRowID,
+        action: 'DELETE'
+      }
+      await fetcher.submit(body, { method: "delete" });
+    } catch (error: any) {
+      console.error(error);
+    }
+
+    setRows((prevRows) =>
+      prevRows.filter((rowValue) => rowValue.id !== +selectedRowID)
+    );
+  };
+
+  const handleDeleteClick = (idRef: any) => {
+    let id = idRef.row.id;
+    setSelectedRowID(() => id);
+    setOpenDeleteModal(() => true);
+  };
+
+  const columns = [
+    { field: "email", headerName: "Email", width: 300, editable: true },
+    { field: "name", headerName: "Name", width: 300, editable: false },
+    {
+      field: "actions",
+      headerName: "Actions",
+      width: 300,
+      renderCell: (idRef: any) => {
+        if (idRef.row.id === "new-value") {
+          idRef.api.setRowMode(idRef.row.id, "edit");
+          idRef.api.setCellFocus(idRef.row.id, "email");
+        }
+        const isInEditMode = idRef.api.getRowMode(idRef.row.id) === "edit";
+        if (isInEditMode) {
+          return (
+            <>
+              <Button
+                variant="contained"
+                color="primary"
+                size="small"
+                onClick={() => handleCancelClick(idRef)}
+                style={{ marginLeft: 16 }}
+              >
+                <CancelIcon color="inherit" />
+              </Button>
+
+              <Button
+                variant="contained"
+                color="secondary"
+                size="small"
+                onClick={() => handleSaveClick(idRef)}
+                style={{ marginLeft: 16 }}
+              >
+                <SaveIcon color="inherit" />
+              </Button>
+            </>
+          );
+        }
+        return (
+          <Button
+            variant="contained"
+            color="primary"
+            size="small"
+            onClick={() => handleDeleteClick(idRef)}
+            style={{ marginLeft: 16 }}
+          >
+            <DeleteIcon color="inherit" />
+          </Button>
+        );
+      },
+    },
+  ];
+
+  return (
+    <>
+      <div style={{ display: "flex", width: "100%", height: "70vh" }}>
+        <div style={{ flexGrow: 1 }}>
+          <ThemeProvider theme={themeWize}>
+            {error && <p style={{ color: "red" }}>{error}</p>}
+            <DataGrid
+              rows={rows}
+              columns={columns}
+              rowsPerPageOptions={[50]}
+              pageSize={50}
+              editMode="row"
+              onRowEditStart={handleRowEditStart}
+              onRowEditStop={handleRowEditStop}
+              onCellFocusOut={handleCellFocusOut}
+              components={{
+                Toolbar: GridEditToolbar,
+              }}
+              componentsProps={{
+                toolbar: { setRows, createButtonText },
+              }}
+            />
+          </ThemeProvider>
+        </div>
+      </div>
+      {/* Confirmation for deletion */}
+      <ConfirmationModal
+        open={openDeleteModal}
+        handleClose={() => setOpenDeleteModal(false)}
+        close={() => setOpenDeleteModal(false)}
+        label="Remove"
+        className="warning"
+        disabled={false}
+        onClick={async () => {
+          deleteConfirmationHandler();
+        }}
+      >
+        <h2>
+          Are you sure you want to remove the Admin role from{" "}
+          {rows[rows.findIndex((row) => row.id === +selectedRowID)]?.email}?
+        </h2>
+        <br />
+      </ConfirmationModal>
+    </>
+  );
+};
+
+export function ErrorBoundary({ error }: { error: Error }) {
+  console.error(error);
+
+  return <div>An unexpected error occurred: {error.message}</div>;
+}
+
+export function CatchBoundary() {
+  const caught = useCatch();
+
+  if (caught.status === 404) {
+    return <div>Project not found</div>;
+  }
+
+  throw new Error(`Unexpected caught response with status: ${caught.status}`);
+}

--- a/app/routes/manager/manager.styles.tsx
+++ b/app/routes/manager/manager.styles.tsx
@@ -1,0 +1,85 @@
+import styled from "@emotion/styled"
+import Tab from "@mui/material/Tab"
+import { Link } from "@remix-run/react"
+
+export const TabStyles = styled(Tab)`
+  text-transform: initial;
+  background-color: #ebebeb;
+  color: #1f1f1f;
+  font-family: Poppins, sans-serif;
+  font-weight: 600;
+  margin-right: 1em;
+  border-radius: 4px;
+  border-color: transparent;
+  box-shadow: 0 0 0 rgba(0, 0, 0, 0);
+  transition: 0.3s box-shadow ease-out;
+  transition-delay: 1;
+
+  &[aria-selected="true"] {
+    background-color: #e94d44;
+    color: white;
+    border-color: transparent;
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.14);
+    transition-delay: 0;
+  }
+`
+
+export const LinkStyles = styled(Link)`
+  margin: 0 10px;
+  padding: 0;
+  align-self: center;
+  font-size: 18px;
+  font-weight: 600;
+  font-family: Poppins, sans-serif;
+  text-transform: initial;
+  text-decoration: none;
+  cursor: pointer;
+  color: #252a2f;
+
+  :hover {
+    color: #e94d44;
+  }
+`
+
+export const EditPanelsStyles = styled.div`
+  margin-top: -1em;
+
+  .MuiBox-root {
+    margin-bottom: 2em;
+  }
+  .MuiTabs-root,
+  .MuiTabs-scroller {
+    overflow: visible;
+  }
+  .MuiTabs-indicator {
+    visibility: hidden;
+  }
+
+  .tabSelected {
+    color: #e94d44;
+  }
+`
+
+export const NavBarTabsStyles = styled.div`
+  background-color: #fff;
+  height: 58px;
+  border-radius: 4px;
+  display: flex;
+  justify-content: flex-start;
+  align-items: center;
+  margin-bottom: 21px;
+
+  & > div {
+    margin-top: 0;
+    margin-left: 20px;
+  }
+
+  @media (max-width: 1025px) {
+    justify-content: center;
+    margin-bottom: 10px;
+
+    & > div {
+      margin-left: 0;
+    }
+  }
+`

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
         "@emotion/styled": "^11.8.1",
         "@mui/icons-material": "^5.8.4",
         "@mui/material": "^5.8.3",
+        "@mui/x-data-grid": "^5.16.0",
         "@prisma/client": "^3.14.0",
         "@remix-run/node": "^1.5.1",
         "@remix-run/react": "^1.5.1",
@@ -2063,9 +2064,9 @@
       }
     },
     "node_modules/@babel/runtime": {
-      "version": "7.18.3",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.18.3.tgz",
-      "integrity": "sha512-38Y8f7YUhce/K7RMwTp7m0uCumpv9hZkitCbBClqQIow1qSbCvGkcegKOXpEWCQLfWmevgRiWokZ1GkpfhbZug==",
+      "version": "7.18.9",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.18.9.tgz",
+      "integrity": "sha512-lkqXDcvlFT5rvEjiu6+QYO+1GXrEHRo2LOtS7E4GtX5ESIZOgepqsZBVIj6Pv+a6zqsya9VCgiK1KAK4BvJDAw==",
       "dependencies": {
         "regenerator-runtime": "^0.13.4"
       },
@@ -2768,15 +2769,15 @@
       }
     },
     "node_modules/@mui/utils": {
-      "version": "5.8.0",
-      "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-5.8.0.tgz",
-      "integrity": "sha512-7LgUtCvz78676iC0wpTH7HizMdCrTphhBmRWimIMFrp5Ph6JbDFVuKS1CwYnWWxRyYKL0QzXrDL0lptAU90EXg==",
+      "version": "5.10.3",
+      "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-5.10.3.tgz",
+      "integrity": "sha512-4jXMDPfx6bpMVuheLaOpKTjpzw39ogAZLeaLj5+RJec3E37/hAZMYjURfblLfTWMMoGoqkY03mNsZaEwNobBow==",
       "dependencies": {
-        "@babel/runtime": "^7.17.2",
+        "@babel/runtime": "^7.18.9",
         "@types/prop-types": "^15.7.5",
         "@types/react-is": "^16.7.1 || ^17.0.0",
         "prop-types": "^15.8.1",
-        "react-is": "^17.0.2"
+        "react-is": "^18.2.0"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -2787,6 +2788,36 @@
       },
       "peerDependencies": {
         "react": "^17.0.0 || ^18.0.0"
+      }
+    },
+    "node_modules/@mui/utils/node_modules/react-is": {
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
+      "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w=="
+    },
+    "node_modules/@mui/x-data-grid": {
+      "version": "5.16.0",
+      "resolved": "https://registry.npmjs.org/@mui/x-data-grid/-/x-data-grid-5.16.0.tgz",
+      "integrity": "sha512-pP1dsNAOWJQoxU/pTHKF/7uDVNASeTA2Ki8fdm6+TVLu8C4ISsg88vGPj8W3ikbdQ1geExzxO1LLX1atQGKTiA==",
+      "dependencies": {
+        "@babel/runtime": "^7.18.9",
+        "@mui/utils": "^5.9.3",
+        "clsx": "^1.2.1",
+        "prop-types": "^15.8.1",
+        "reselect": "^4.1.6"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/mui"
+      },
+      "peerDependencies": {
+        "@mui/material": "^5.4.1",
+        "@mui/system": "^5.4.1",
+        "react": "^17.0.2 || ^18.0.0",
+        "react-dom": "^17.0.2 || ^18.0.0"
       }
     },
     "node_modules/@nodelib/fs.scandir": {
@@ -5298,9 +5329,9 @@
       }
     },
     "node_modules/clsx": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.1.1.tgz",
-      "integrity": "sha512-6/bPho624p3S2pMyvP5kKBPXnI3ufHLObBFCfgx+LkeR5lg2XYy2hqZqUf45ypD8COn2bhgGJSUE+l5dhNBieA==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
+      "integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg==",
       "engines": {
         "node": ">=6"
       }
@@ -13798,6 +13829,11 @@
         "node": ">=0.10.5"
       }
     },
+    "node_modules/reselect": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-4.1.6.tgz",
+      "integrity": "sha512-ZovIuXqto7elwnxyXbBtCPo9YFEr3uJqj2rRbcOOog1bmu2Ag85M4hixSwFWyaBMKXNgvPaJ9OSu9SkBPIeJHQ=="
+    },
     "node_modules/resolve": {
       "version": "1.22.0",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.0.tgz",
@@ -18353,9 +18389,9 @@
       }
     },
     "@babel/runtime": {
-      "version": "7.18.3",
-      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.18.3.tgz",
-      "integrity": "sha512-38Y8f7YUhce/K7RMwTp7m0uCumpv9hZkitCbBClqQIow1qSbCvGkcegKOXpEWCQLfWmevgRiWokZ1GkpfhbZug==",
+      "version": "7.18.9",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.18.9.tgz",
+      "integrity": "sha512-lkqXDcvlFT5rvEjiu6+QYO+1GXrEHRo2LOtS7E4GtX5ESIZOgepqsZBVIj6Pv+a6zqsya9VCgiK1KAK4BvJDAw==",
       "requires": {
         "regenerator-runtime": "^0.13.4"
       }
@@ -18842,15 +18878,34 @@
       "requires": {}
     },
     "@mui/utils": {
-      "version": "5.8.0",
-      "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-5.8.0.tgz",
-      "integrity": "sha512-7LgUtCvz78676iC0wpTH7HizMdCrTphhBmRWimIMFrp5Ph6JbDFVuKS1CwYnWWxRyYKL0QzXrDL0lptAU90EXg==",
+      "version": "5.10.3",
+      "resolved": "https://registry.npmjs.org/@mui/utils/-/utils-5.10.3.tgz",
+      "integrity": "sha512-4jXMDPfx6bpMVuheLaOpKTjpzw39ogAZLeaLj5+RJec3E37/hAZMYjURfblLfTWMMoGoqkY03mNsZaEwNobBow==",
       "requires": {
-        "@babel/runtime": "^7.17.2",
+        "@babel/runtime": "^7.18.9",
         "@types/prop-types": "^15.7.5",
         "@types/react-is": "^16.7.1 || ^17.0.0",
         "prop-types": "^15.8.1",
-        "react-is": "^17.0.2"
+        "react-is": "^18.2.0"
+      },
+      "dependencies": {
+        "react-is": {
+          "version": "18.2.0",
+          "resolved": "https://registry.npmjs.org/react-is/-/react-is-18.2.0.tgz",
+          "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w=="
+        }
+      }
+    },
+    "@mui/x-data-grid": {
+      "version": "5.16.0",
+      "resolved": "https://registry.npmjs.org/@mui/x-data-grid/-/x-data-grid-5.16.0.tgz",
+      "integrity": "sha512-pP1dsNAOWJQoxU/pTHKF/7uDVNASeTA2Ki8fdm6+TVLu8C4ISsg88vGPj8W3ikbdQ1geExzxO1LLX1atQGKTiA==",
+      "requires": {
+        "@babel/runtime": "^7.18.9",
+        "@mui/utils": "^5.9.3",
+        "clsx": "^1.2.1",
+        "prop-types": "^15.8.1",
+        "reselect": "^4.1.6"
       }
     },
     "@nodelib/fs.scandir": {
@@ -20774,9 +20829,9 @@
       }
     },
     "clsx": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.1.1.tgz",
-      "integrity": "sha512-6/bPho624p3S2pMyvP5kKBPXnI3ufHLObBFCfgx+LkeR5lg2XYy2hqZqUf45ypD8COn2bhgGJSUE+l5dhNBieA=="
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-1.2.1.tgz",
+      "integrity": "sha512-EcR6r5a8bj6pu3ycsa/E/cKVGuTgZJZdsyUYHOksG/UHIiKfjxzRxYJpyVBwYaQeOvghal9fcc4PidlgzugAQg=="
     },
     "collection-visit": {
       "version": "1.0.0",
@@ -26988,6 +27043,11 @@
       "resolved": "https://registry.npmjs.org/requireindex/-/requireindex-1.2.0.tgz",
       "integrity": "sha512-L9jEkOi3ASd9PYit2cwRfyppc9NoABujTP8/5gFcbERmo5jUoAKovIC3fsF17pkTnGsrByysqX+Kxd2OTNI1ww==",
       "dev": true
+    },
+    "reselect": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/reselect/-/reselect-4.1.6.tgz",
+      "integrity": "sha512-ZovIuXqto7elwnxyXbBtCPo9YFEr3uJqj2rRbcOOog1bmu2Ag85M4hixSwFWyaBMKXNgvPaJ9OSu9SkBPIeJHQ=="
     },
     "resolve": {
       "version": "1.22.0",

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "@emotion/styled": "^11.8.1",
     "@mui/icons-material": "^5.8.4",
     "@mui/material": "^5.8.3",
+    "@mui/x-data-grid": "^5.16.0",
     "@prisma/client": "^3.14.0",
     "@remix-run/node": "^1.5.1",
     "@remix-run/react": "^1.5.1",

--- a/prisma/migrations/20220830205436_user_name_optional/migration.sql
+++ b/prisma/migrations/20220830205436_user_name_optional/migration.sql
@@ -1,0 +1,2 @@
+-- AlterTable
+ALTER TABLE "User" ALTER COLUMN "name" DROP NOT NULL;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -10,7 +10,7 @@ generator client {
 model User {
   id    String @id @default(cuid())
   email String @unique
-  name  String
+  name  String?
   role  String @default("USER")
 
   createdAt DateTime @default(now())


### PR DESCRIPTION
# What does this PR do?

This PR adds the Admins tab from the Manager page, it allows Admin users to add or remove new Admins

# Where should the reviewer start?

The reviewers should set themselves as `ADMIN` in the `User` table and go to the manage page in the profile dropdown

# How should this be manually tested?

- Go to the Manager page
- Go to the Admins tab
- Check that all ADMIN Users are listed
- Play with the functionalities (Add and remove) everything should be working fine.

# What are the relevant tickets?

#26 

# Screenshots

<img width="1172" alt="image" src="https://user-images.githubusercontent.com/96010361/188724046-bc3a3228-4e77-495e-a4f1-c348ece4cddc.png">

<img width="1171" alt="image" src="https://user-images.githubusercontent.com/96010361/188724093-7c36f961-da69-446c-a7d4-89da597d51a5.png">


# Questions

PENDING: Migrate the Filter Tags tab

# Checklist

<!-- Verify that you have done all of the following and mark them as done. -->

- [ ] I added the necessary documentation, if appropriate.
- [ ] I added tests to prove that my fix is effective or my feature works.
- [X] I reviewed existing Pull Requests before submitting mine.