### PR TITLE
Issue/filter status fix

### DIFF
--- a/app/constants.ts
+++ b/app/constants.ts
@@ -67,4 +67,6 @@ export const contributorPath = [
   },
 ]
 
-export const stageOptions = [{ name: "idea" }, { name: "ongoing project" }, { name: "none" }]
+export const ongoingStage =  "ongoing project"
+export const ideaStage =  "idea"
+export const stageOptions = [{ name: ideaStage }, { name: ongoingStage }, { name: "none" }]

--- a/app/models/project.server.ts
+++ b/app/models/project.server.ts
@@ -121,7 +121,6 @@ export async function searchProjects({
 
   if (status.length > 0) {
     where = Prisma.sql`${where} AND p.status IN (${Prisma.join(status)})`
-    having = joinCondition(having, Prisma.sql`COUNT(DISTINCT p.status) = ${status.length}`)
   }
 
   if (skill.length > 0) {

--- a/app/routes/index.tsx
+++ b/app/routes/index.tsx
@@ -2,7 +2,17 @@ import type {
   LoaderFunction,
 } from "@remix-run/node";
 import {   redirect } from "@remix-run/server-runtime";
+import {
+  getProjectStatuses
+} from "~/models/status.server"
+import { ongoingStage } from "~/constants"
 
-export const loader: LoaderFunction = async ( ) => {
-  return redirect("/projects");
+
+export const loader: LoaderFunction = async ({ request } ) => {
+  const ongoingStatuses = (await getProjectStatuses()).filter((status) => status.stage === ongoingStage);
+  const url = new URL(request.url + "projects");
+  ongoingStatuses.forEach((status) =>{
+  url.searchParams.append("status", status.name);
+  });
+  return redirect(url.toString());
 };

--- a/app/routes/projects/index.tsx
+++ b/app/routes/projects/index.tsx
@@ -125,7 +125,7 @@ export default function Projects() {
 
   //Tabs selection logic
   const isMyProposalTab = () => {
-    return searchParams.getAll("status").includes(myProposalsTab.searchParams.getAll('status')[0]);
+    return searchParams.get("q") === myProposalsTab.searchParams.get('q')
   }
 
   const isIdeasTab = () => {
@@ -148,6 +148,7 @@ export default function Projects() {
   }
 
   const getTabClass = (tab: string) => {
+    console.log(tab)
     if (
         (tab == myProposalsTab.name && isMyProposalTab()) ||
         (tab == ideasTab.name && isIdeasTab()) ||
@@ -179,20 +180,20 @@ export default function Projects() {
         <div className="homeWrapper__navbar">
           <div className="homeWrapper__navbar__tabs">
             <div
-              className={`homeWrapper__navbar__tabs--title ${getTabClass("ideas")}`}
-              onClick={() => handleTabChange("ideas")}
+              className={`homeWrapper__navbar__tabs--title ${getTabClass(ideasTab.name)}`}
+              onClick={() => handleTabChange(ideasTab.name)}
             >
               Ideas
             </div>
             <div
-              className={`homeWrapper__navbar__tabs--title ${getTabClass("activeProjects")}`}
-              onClick={() => handleTabChange("activeProjects")}
+              className={`homeWrapper__navbar__tabs--title ${getTabClass(activeProjectsTab.name)}`}
+              onClick={() => handleTabChange(activeProjectsTab.name)}
             >
               Active Projects
             </div>
             <div
-              className={`homeWrapper__navbar__tabs--title ${getTabClass("myProposals")}`}
-              onClick={() => handleTabChange("myProposals")}
+              className={`homeWrapper__navbar__tabs--title ${getTabClass(myProposalsTab.name)}`}
+              onClick={() => handleTabChange(myProposalsTab.name)}
             >
               My Projects
             </div>

--- a/app/routes/projects/index.tsx
+++ b/app/routes/projects/index.tsx
@@ -23,6 +23,12 @@ type LoaderData = {
 const ITEMS_PER_PAGE = 50
 const FACETS = ["status", "skill", "label", "disciplines", "location", "tier", "role", "missing"]
 
+interface Tab { 
+  name: string
+  title: string
+  searchParams: URLSearchParams
+}
+
 export const loader: LoaderFunction = async ({ request }) => {
   const profile = await requireProfile(request);
   const url = new URL(request.url);
@@ -77,11 +83,29 @@ export default function Projects() {
     missingFacets,
     count,
   }} = useLoaderData() as LoaderData
+  const myPropQuery =  "myProposals"
+  const activeProjectsTab: Tab = {
+    name: "activeProjects",
+    title: "Active Projects",
+    searchParams: new URLSearchParams([["status", "Idea in Progress"], ["status", "Need SME Review"], ["status", "Need Tier Review"]])
+  };
+  const myProposalsTab = {
+    name: "myProposals",
+    title: "My Proposals",
+    searchParams: new URLSearchParams({ q: myPropQuery })
+  }
+  const ideasTab = {
+    name: "ideas",
+    title: "Ideas",
+    searchParams: new URLSearchParams([["status", "Idea Submitted"]])
+  }
+  const tabs: Array<Tab> = [myProposalsTab, activeProjectsTab, ideasTab];
 
   const goToPreviousPage = () => {
     searchParams.set("page", String(page - 1))
     setSearchParams(searchParams)
   }
+
   const goToNextPage = () => {
     searchParams.set("page", String(page + 1))
     setSearchParams(searchParams)
@@ -101,30 +125,33 @@ export default function Projects() {
 
   //Tabs selection logic
   const isMyProposalTab = () => {
-    return searchParams.get("q") === "myProposals"
+    return searchParams.getAll("status").includes(myProposalsTab.searchParams.getAll('status')[0]);
   }
+
   const isIdeasTab = () => {
-    return searchParams.getAll("status").includes("Idea Submitted")
+    return searchParams.getAll("status").includes(ideasTab.searchParams.getAll('status')[0]);
   }
-  const isInProgressTab = () => {
-    return searchParams.getAll("status").includes("Idea in Progress")
+
+  const isInProgressTab = () => { 
+    return searchParams.getAll("status").includes(activeProjectsTab.searchParams.getAll('status')[0]);
   }
+
   const getTitle = () => {
     if (isMyProposalTab()) {
-      return "MyProposals"
+      return myProposalsTab.title;
     } else if (isIdeasTab()) {
-      return "Ideas"
+      return ideasTab.title;
     } else if (isInProgressTab()) {
-      return "Active Projects"
-    } else {
-      return "All Projects"
+      return activeProjectsTab.title;
     }
+    return "All Projects";
   }
+
   const getTabClass = (tab: string) => {
     if (
-        (tab == "myProposals" && isMyProposalTab()) ||
-        (tab == "ideas" && isIdeasTab()) ||
-        (tab == "activeProjects" && isInProgressTab())
+        (tab == myProposalsTab.name && isMyProposalTab()) ||
+        (tab == ideasTab.name && isIdeasTab()) ||
+        (tab == activeProjectsTab.name && isInProgressTab())
     ) {
       return "homeWrapper__navbar__tabs--title--selected"
     } else {
@@ -133,12 +160,9 @@ export default function Projects() {
   }
 
   const handleTabChange = (selectedTab: string) => {
-    if (selectedTab === "activeProjects") {
-      setSearchParams(new URLSearchParams({status: "Idea in Progress" }))
-    } else if (selectedTab === "myProposals") {
-      setSearchParams(new URLSearchParams({q: "myProposals" }))
-    } else {
-      setSearchParams(new URLSearchParams({status: "Idea Submitted" }))
+    let params = tabs.find(tab => tab.name === selectedTab)?.searchParams;
+    if(params){
+      setSearchParams(params)
     }
   }
 

--- a/app/routes/projects/index.tsx
+++ b/app/routes/projects/index.tsx
@@ -52,8 +52,9 @@ export const loader: LoaderFunction = async ({ request }) => {
   const missing = url.searchParams.getAll("missing");
   const field = url.searchParams.get("field") || "";
   const order = url.searchParams.get("order") || "";
-  const ongoingStatuses = (await getProjectStatuses()).filter((status) => status.stage === ongoingStage);
-  const ideaStatuses = (await getProjectStatuses()).filter((status) => status.stage === ideaStage);
+  const statuses = await getProjectStatuses()
+  const ongoingStatuses = statuses.filter((status) => status.stage === ongoingStage);
+  const ideaStatuses = statuses.filter((status) => status.stage === ideaStage);
 
   const data = await searchProjects({
     search,
@@ -197,24 +198,17 @@ export default function Projects() {
       <Wrapper className="homeWrapper" filtersOpen={openMobileFilters}>
         <div className="homeWrapper__navbar">
           <div className="homeWrapper__navbar__tabs">
-            <div
-              className={`homeWrapper__navbar__tabs--title ${getTabClass(ideasTab.name)}`}
-              onClick={() => handleTabChange(ideasTab.name)}
-            >
-              Ideas
-            </div>
-            <div
-              className={`homeWrapper__navbar__tabs--title ${getTabClass(activeProjectsTab.name)}`}
-              onClick={() => handleTabChange(activeProjectsTab.name)}
-            >
-              Active Projects
-            </div>
-            <div
-              className={`homeWrapper__navbar__tabs--title ${getTabClass(myProposalsTab.name)}`}
-              onClick={() => handleTabChange(myProposalsTab.name)}
-            >
-              My Projects
-            </div>
+            {
+              tabs.map(tab => (
+                <div
+                  className={`homeWrapper__navbar__tabs--title ${getTabClass(tab.name)}`}
+                  onClick={() => handleTabChange(tab.name)}
+                  key={tab.name}
+                >
+                  {tab.title}
+                </div>
+              ))
+            }
           </div>
         </div>
         <div className="homeWrapper--content">


### PR DESCRIPTION
<!-- PR title format: `<Bug> - 23 - Default filter does not show all active projects` -->

# What does this PR do?

Uses the status according to the stages to show ongoing projects, and ideas in the tabs "Ideas" and "Active projects"
Redirect to the "Active projects" tab after login and when the Wizeline logo is clicked

# Where should the reviewer start?

app/routes/projects/index.ts

# How should this be manually tested?

1. Login
2. The filter should show the selected statuses "Idea in progress" "Need SME review" and "Need Tier review"

1. Click on Wizeline's logo
2. The filter should show the selected statuses "Idea in progress" "Need SME review" and "Need Tier review"

1. Change tabs
2. The tab's name, status, and styles should match.

# Any background context you want to provide?

This is using the new stages to relate the tabs with the status

# What are the relevant tickets?

#23 

