### PR TITLE
#43 - Feat - add the sorting functionality to the projects page

### DIFF
--- a/app/core/components/SortInput/index.tsx
+++ b/app/core/components/SortInput/index.tsx
@@ -1,51 +1,41 @@
-import React, { useEffect, useState } from "react"
 import { MenuItem, TextField } from "@mui/material"
 
 interface iProps {
   setSortQuery: (query: { field: string; order: string }) => void
+  sortBy: string
 }
 
-export const SortInput = ({ setSortQuery }: iProps) => {
-  const [sortBy, setSortBy] = useState("")
-
+export const SortInput = ({ setSortQuery, sortBy }: iProps) => {
   //sorting options
   const sortOptions = [
     {
       label: "Most recent",
       value: "mostRecent",
+      order: "desc",
     },
     {
       label: "Most voted",
-      value: "mostVoted",
+      value: "votesCount",
+      order: "desc",
     },
     {
       label: "Project Members",
       value: "projectMembers",
+      order: "desc",
     },
     {
       label: "Last Updated",
-      value: "lastUpdated",
+      value: "updatedAt",
+      order: "desc",
     },
   ]
 
   const handleSortByChange = (e: any) => {
-    setSortBy(e.target.value)
+    setSortQuery({
+      field: e.target.value,
+      order: sortOptions.find((option) => option.value === e.target.value)?.order || "",
+    })
   }
-
-  useEffect(() => {
-    if (sortBy === "mostRecent") {
-      setSortQuery({ field: "createdAt", order: "desc" })
-    }
-    if (sortBy === "mostVoted") {
-      setSortQuery({ field: "votesCount", order: "desc" })
-    }
-    if (sortBy === "projectMembers") {
-      setSortQuery({ field: sortBy, order: "desc" })
-    }
-    if (sortBy === "lastUpdated") {
-      setSortQuery({ field: "updatedAt", order: "desc" })
-    }
-  }, [sortBy, setSortQuery])
 
   return (
     <TextField


### PR DESCRIPTION
# What does this PR do?

This PR adds the sorting functionality in the Projects page

# Where should the reviewer start?

In the Projects page

# How should this be manually tested?

- Go to the Projects page and change the value in the Sort By select, the cards should change based on the selected option
- Change tab to any of the other options, the Sort By select should be reset in order to avoid bugs, after that you can select again any of the options and validate that the cards are sorted correctly

# What are the relevant tickets?

#43 

# Checklist

<!-- Verify that you have done all of the following and mark them as done. -->

- [ ] I added the necessary documentation, if appropriate.
- [ ] I added tests to prove that my fix is effective or my feature works.
- [X] I reviewed existing Pull Requests before submitting mine.