### PR TITLE
Reload:  Enhancement/edit related projects in projects detail page

### DIFF
--- a/app/core/components/RelatedProjectsSection.tsx
+++ b/app/core/components/RelatedProjectsSection.tsx
@@ -1,26 +1,154 @@
-import { Chip, Box } from "@mui/material";
+import { useFetcher } from "@remix-run/react";
+import {
+  Autocomplete,
+  TextField,
+  Alert,
+  Chip,
+  Box,
+  IconButton,
+} from "@mui/material";
+import { EditSharp, Close } from "@mui/icons-material";
+import { useState, useEffect } from "react";
 import Link from "./Link";
 interface IProps {
   relatedProjects: any[];
+  allowEdit: Boolean;
+  projectsList: { id: string; name: string }[];
+  projectId: string;
 }
 
-function RelatedProjectsSection({ relatedProjects }: IProps) {
+function RelatedProjectsSection({
+  relatedProjects,
+  allowEdit,
+  projectsList,
+  projectId,
+}: IProps) {
+  const fetcher = useFetcher();
+  const [isEditActive, setIsEditActive] = useState(false);
+  const handleChangeEditView = (val: Boolean) => setIsEditActive(!isEditActive);
+  const [selectedRelatedProjects, setSelectedRelatedProjects] =
+    useState(relatedProjects);
+  const [error, setError] = useState<string>("");
+  const handleChange = (v: any) => {
+    setSelectedRelatedProjects(() => v);
+  };
+
+  const submitEdition = async () => {
+    try {
+      const body = {
+        ...fetcher.data,
+        projectId,
+        relatedProjects: JSON.stringify(selectedRelatedProjects),
+        action: "EDIT_RELATED_PROJECTS",
+      };
+      await fetcher.submit(body, { method: "post" });
+    } catch (error: any) {
+      console.error(error);
+    }
+    handleChangeEditView(false);
+  };
+
+  useEffect(() => {
+    //It handles the fetcher error from the response
+    if (fetcher.state === "idle" && fetcher.data) {
+      if (fetcher.data.error) {
+        setError(fetcher.data.error);
+      } else {
+        setError("");
+      }
+    }
+  }, [fetcher]);
+
+  useEffect(() => {
+    setSelectedRelatedProjects(relatedProjects);
+  }, [relatedProjects]);
+
   return (
     <>
       <big>Related Projects</big>
-      <Box>
-        {relatedProjects.map((item, i) => {
-          return (
-            <Link className="link_button" key={i} to={`/projects/${item.id}`}>
-              <Chip
-                className="chip-hover"
-                sx={{ margin: "1em .5em" }}
-                label={item?.name}
-              ></Chip>
-            </Link>
-          );
-        })}
-      </Box>
+      {/* {JSON.stringify(selectedRelatedProjects,null,2)} */}
+      {allowEdit && isEditActive ? (
+        <>
+          <IconButton
+            sx={{ margin: "1em .5em" }}
+            onClick={() => handleChangeEditView(false)}
+          >
+            <Close>Cancel</Close>
+          </IconButton>
+        </>
+      ) : (
+        <IconButton
+          sx={{ margin: "1em .5em" }}
+          onClick={() => handleChangeEditView(true)}
+        >
+          <EditSharp></EditSharp>
+        </IconButton>
+      )}
+      <div>
+        {isEditActive && (
+          <>
+            <fetcher.Form method="post">
+              <Autocomplete
+                multiple
+                id="relatedProjects"
+                options={projectsList.filter((proj) => proj.id !== projectId)}
+                getOptionLabel={(option) => option.name}
+                value={selectedRelatedProjects}
+                onChange={(event, value: { id: string; name: string }[] | []) =>
+                  handleChange(value)
+                }
+                defaultValue={relatedProjects}
+                filterSelectedOptions
+                isOptionEqualToValue={(option, value) =>
+                  option.name === value.name
+                }
+                renderInput={(params) => (
+                  <TextField
+                    name="relateProjects"
+                    label="Related Projects"
+                    {...params}
+                    placeholder="Add Related Projects..."
+                  />
+                )}
+              />
+              {error && <span>{JSON.stringify(error)}</span>}
+              <div className="margin-vertical-separator">
+                <button
+                  disabled={fetcher.state === "submitting"}
+                  className="primary"
+                  onClick={() => submitEdition()}
+                >
+                  Submit
+                </button>
+              </div>
+              {error && (
+                <Alert severity="warning">Information could not be saved</Alert>
+              )}
+            </fetcher.Form>
+          </>
+        )}
+      </div>
+
+      {!isEditActive && (
+        <Box>
+          {relatedProjects.map((item, i) => {
+            return (
+              <Link
+                className="link_button"
+                key={i}
+                to={`/projects/${item.id}`}
+                prefetch="render"
+              >
+                <Chip
+                  className="chip-hover"
+                  sx={{ margin: "1em .5em" }}
+                  label={item?.name}
+                ></Chip>
+              </Link>
+            );
+          })}
+        </Box>
+      )}
     </>
   );
 }

--- a/app/core/components/RelatedProjectsSection.tsx
+++ b/app/core/components/RelatedProjectsSection.tsx
@@ -6,6 +6,7 @@ import {
   Chip,
   Box,
   IconButton,
+  Button,
 } from "@mui/material";
 import { EditSharp, Close } from "@mui/icons-material";
 import { useEffect, useState } from "react";
@@ -61,21 +62,15 @@ function RelatedProjectsSection({
 
   return (
     <>
-      <big>Related Projects</big>
+      <big>Related Projects</big>&nbsp;
       {allowEdit && isEditActive ? (
         <>
-          <IconButton
-            sx={{ margin: "1em .5em" }}
-            onClick={() => handleChangeEditView(false)}
-          >
+          <IconButton onClick={() => handleChangeEditView(false)}>
             <Close>Cancel</Close>
           </IconButton>
         </>
       ) : (
-        <IconButton
-          sx={{ margin: "1em .5em" }}
-          onClick={() => handleChangeEditView(true)}
-        >
+        <IconButton onClick={() => handleChangeEditView(true)}>
           <EditSharp></EditSharp>
         </IconButton>
       )}
@@ -120,14 +115,13 @@ function RelatedProjectsSection({
                 )}
               />
               {error && <span>{error}</span>}
-              <div className="margin-vertical-separator">
-                <button
-                  disabled={transition.state === "submitting"}
-                  className="primary"
-                >
-                  Submit
-                </button>
-              </div>
+              <Button
+                variant="contained"
+                type="submit"
+                disabled={transition.state === "submitting"}
+              >
+                Submit
+              </Button>
               {error && (
                 <Alert severity="warning">Information could not be saved</Alert>
               )}
@@ -135,7 +129,6 @@ function RelatedProjectsSection({
           </>
         )}
       </div>
-
       {!isEditActive && (
         <Box>
           {relatedProjects.map((item, i) => {

--- a/app/models/project.server.ts
+++ b/app/models/project.server.ts
@@ -53,7 +53,7 @@ interface FacetOutput {
 }
 
 interface RelatedProjectInput {
-  relatedProjects: [{ id: string; name: string }];
+  relatedProjects: { id: string }[];
 }
 
 export class SearchProjectsError extends Error {
@@ -204,12 +204,7 @@ export async function getProjects(where: ProjectWhereInput) {
   try {
     const projects = await db.projects.findMany({
       where,
-      include: {
-        projectStatus: true,
-        owner: true,
-        skills: true,
-        projectMembers: true,
-      },
+      select: { id: true, name: true },
     });
     return projects;
   } catch (e) {

--- a/app/routes/projects/$projectId/index.tsx
+++ b/app/routes/projects/$projectId/index.tsx
@@ -438,12 +438,14 @@ export default function ProjectDetailsPage() {
         </Grid>
       </Container>
       <Container>
-        <RelatedProjectsSection
-          allowEdit={isTeamMember}
-          relatedProjects={project.relatedProjects}
-          projectsList={projectsList}
-          projectId={project.id || ""}
-        />
+        <Paper sx={{ padding: 2, marginBottom: 2 }}>
+          <RelatedProjectsSection
+            allowEdit={isTeamMember}
+            relatedProjects={project.relatedProjects}
+            projectsList={projectsList}
+            projectId={project.id || ""}
+          />
+        </Paper>
       </Container>
       <Container>
         <ContributorPathReport

--- a/app/routes/projects/$projectId/index.tsx
+++ b/app/routes/projects/$projectId/index.tsx
@@ -18,6 +18,7 @@ import {
   getProjectTeamMember,
   isProjectTeamMember,
   getProject,
+  getProjects,
 } from "~/models/project.server";
 import type { ProjectComplete } from "~/models/project.server";
 
@@ -54,6 +55,7 @@ type LoaderData = {
   membership: ProjectMembers | undefined;
   profile: Profiles;
   project: ProjectComplete;
+  projectsList: Awaited<ReturnType<typeof getProjects>>;
   profileId: string;
 };
 
@@ -73,6 +75,7 @@ export const loader: LoaderFunction = async ({ request, params }) => {
   const user = await requireUser(request);
   const profile = await requireProfile(request);
   const isTeamMember = isProjectTeamMember(profile.id, project);
+  const projectsList = await getProjects({});
 
   const membership = getProjectTeamMember(profile.id, project);
   const isAdmin = user.role == adminRoleName;
@@ -83,6 +86,7 @@ export const loader: LoaderFunction = async ({ request, params }) => {
     membership,
     profile,
     project,
+    projectsList,
     profileId,
   });
 };
@@ -137,8 +141,15 @@ export default function ProjectDetailsPage() {
     setShowJoinModal(false);
   };
 
-  const { isAdmin, isTeamMember, profile, membership, project, profileId } =
-    useLoaderData() as LoaderData;
+  const {
+    isAdmin,
+    isTeamMember,
+    profile,
+    membership,
+    project,
+    projectsList,
+    profileId,
+  } = useLoaderData() as LoaderData;
   const [showJoinModal, setShowJoinModal] = useState<boolean>(false);
 
   invariant(project, "project not found");
@@ -427,7 +438,12 @@ export default function ProjectDetailsPage() {
         </Grid>
       </Container>
       <Container>
-        <RelatedProjectsSection relatedProjects={project.relatedProjects} />
+        <RelatedProjectsSection
+          allowEdit={isTeamMember}
+          relatedProjects={project.relatedProjects}
+          projectsList={projectsList}
+          projectId={project.id || ""}
+        />
       </Container>
       <Container>
         <ContributorPathReport

--- a/app/routes/projects/$projectId/updateRelatedProjects.ts
+++ b/app/routes/projects/$projectId/updateRelatedProjects.ts
@@ -20,7 +20,7 @@ export const action: ActionFunction = async ({ request, params }) => {
   const isAdmin = user.role == adminRoleName;
   const isTeamMember = isProjectTeamMember(profile.id, project);
 
-  if (!isAdmin || !isTeamMember) {
+  if (!isAdmin && !isTeamMember) {
     return validationError({
       fieldErrors: {
         formError: "Operation not allowed",

--- a/app/routes/projects/$projectId/updateRelatedProjects.ts
+++ b/app/routes/projects/$projectId/updateRelatedProjects.ts
@@ -1,0 +1,48 @@
+import type { ActionFunction } from "@remix-run/node";
+import { redirect } from "@remix-run/node";
+import invariant from "tiny-invariant";
+import { requireProfile, requireUser } from "~/session.server";
+import { validator } from "~/core/components/RelatedProjectsSection";
+import { validationError } from "remix-validated-form";
+import {
+  getProject,
+  isProjectTeamMember,
+  updateRelatedProjects,
+} from "~/models/project.server";
+import { adminRoleName } from "~/constants";
+
+export const action: ActionFunction = async ({ request, params }) => {
+  invariant(params.projectId, "projectId could not be found");
+  const projectId = params.projectId;
+  const profile = await requireProfile(request);
+  const user = await requireUser(request);
+  const project = await getProject({ id: params.projectId });
+  const isAdmin = user.role == adminRoleName;
+  const isTeamMember = isProjectTeamMember(profile.id, project);
+
+  if (!isAdmin || !isTeamMember) {
+    return validationError({
+      fieldErrors: {
+        formError: "Operation not allowed",
+      },
+    });
+  }
+
+  const result = await validator.validate(await request.formData());
+  if (result.error != undefined) return validationError(result.error);
+
+  try {
+    await updateRelatedProjects({
+      id: projectId,
+      data: result.data,
+    });
+    return redirect(`/projects/${projectId}`);
+  } catch (e) {
+    console.log(e);
+    return validationError({
+      fieldErrors: {
+        formError: "Server failed",
+      },
+    });
+  }
+};


### PR DESCRIPTION
# What does this PR do?

It's the same as #90 but with fresh branch from main because merging was very hard, and using some of the same code patterns used at #91.

Adds edit related projects section to the project's details page

# Where should the reviewer start?

Check changes on:
app/core/components/RelatedProjectsSection.tsx
app/routes/projects/$projectId/index.tsx

# How should this be manually tested?

1. Run the projects locally
2. Go to a project's detail page.
3. Click the edit button.
4. Add/Remove related projects
5. Save changes
6. Use the related project's "chip" buttons to navigate to the related projects.

# Any background context you want to provide?

This change was added in order to facilitate edit related projects without going to the main edit page of a project.

This version works by sending information as stringified JSON (I tried sending information as arrays as recommended, but I wasn't able to do so without causing a navigation).

# What are the relevant tickets?

Closes #61 

# Screenshots

<img width="1370" alt="Captura de Pantalla 2022-12-22 a la(s) 1 49 58" src="https://user-images.githubusercontent.com/90728303/209084381-ddc77459-e1a4-405b-aa10-0bace1566ca1.png">

<img width="1360" alt="Captura de Pantalla 2022-12-22 a la(s) 1 50 10" src="https://user-images.githubusercontent.com/90728303/209084375-324a8b7a-c213-4570-9b7c-0ddd8cc90119.png">

# Questions

<!-- List questions or concerns directed to the reviewers, if necessary. -->

# Checklist

<!-- Verify that you have done all of the following and mark them as done. -->

- [ ] I added the necessary documentation, if appropriate.
- [ ] I added tests to prove that my fix is effective or my feature works.
- [ ] I reviewed existing Pull Requests before submitting mine.