### PR TITLE
#105 - fix the tiers link from the proposal cards

### DIFF
--- a/app/core/components/ProposalCard/ProposalCard.styles.tsx
+++ b/app/core/components/ProposalCard/ProposalCard.styles.tsx
@@ -1,5 +1,4 @@
 import styled from "@emotion/styled";
-import { styled as muiStyled } from "@mui/material";
 
 export const ProposalCardWrap = styled.div`
   display: flex;
@@ -116,6 +115,3 @@ export const ProposalCardWrap = styled.div`
     color: #ececec;
   }
 `;
-export const StyledLink = muiStyled("a")(({ theme }) => ({
-  color: theme.palette.primary.main,
-}));

--- a/app/core/components/ProposalCard/ProposalCard.styles.tsx
+++ b/app/core/components/ProposalCard/ProposalCard.styles.tsx
@@ -1,4 +1,5 @@
 import styled from "@emotion/styled";
+import { styled as muiStyled } from "@mui/material";
 
 export const ProposalCardWrap = styled.div`
   display: flex;
@@ -115,3 +116,6 @@ export const ProposalCardWrap = styled.div`
     color: #ececec;
   }
 `;
+export const StyledLink = muiStyled("a")(({ theme }) => ({
+  color: theme.palette.primary.main,
+}));

--- a/app/core/components/ProposalCard/index.tsx
+++ b/app/core/components/ProposalCard/index.tsx
@@ -4,8 +4,7 @@ import ThumbUpIcon from "@mui/icons-material/ThumbUp";
 import PersonIcon from "@mui/icons-material/Person";
 import HelpIcon from "@mui/icons-material/Help";
 
-import { ProposalCardWrap } from "./ProposalCard.styles";
-import Link from "../Link";
+import { ProposalCardWrap, StyledLink } from "./ProposalCard.styles";
 
 interface IProps {
   id: string | number;
@@ -78,8 +77,8 @@ export const ProposalCard = (props: IProps) => {
                       {props.status}
                     </span>
                     <div className="ProposalCard__tier">
-                      <Link
-                        to="https://wizeline.atlassian.net/wiki/spaces/wiki/pages/3075342381/Innovation+Tiers"
+                      <StyledLink
+                        href="https://wizeline.atlassian.net/wiki/spaces/wiki/pages/3075342381/Innovation+Tiers"
                         target="_blank"
                         rel="noreferrer"
                         onClick={stopEvent}
@@ -87,7 +86,7 @@ export const ProposalCard = (props: IProps) => {
                         <label className="ProposalCard__head__description--tier">
                           {props.tierName}
                         </label>
-                      </Link>
+                      </StyledLink>
                       <label
                         className="ProposalCard__head__description--tier--extra"
                         title="Maturation framework for innovation projects"

--- a/app/core/components/ProposalCard/index.tsx
+++ b/app/core/components/ProposalCard/index.tsx
@@ -1,10 +1,10 @@
-import { CardActionArea, CardContent, Card, Chip } from "@mui/material";
+import { CardActionArea, CardContent, Card, Chip, Link } from "@mui/material";
 import EllipsisText from "app/core/components/EllipsisText";
 import ThumbUpIcon from "@mui/icons-material/ThumbUp";
 import PersonIcon from "@mui/icons-material/Person";
 import HelpIcon from "@mui/icons-material/Help";
 
-import { ProposalCardWrap, StyledLink } from "./ProposalCard.styles";
+import { ProposalCardWrap } from "./ProposalCard.styles";
 
 interface IProps {
   id: string | number;
@@ -77,16 +77,17 @@ export const ProposalCard = (props: IProps) => {
                       {props.status}
                     </span>
                     <div className="ProposalCard__tier">
-                      <StyledLink
+                      <Link
                         href="https://wizeline.atlassian.net/wiki/spaces/wiki/pages/3075342381/Innovation+Tiers"
                         target="_blank"
                         rel="noreferrer"
                         onClick={stopEvent}
+                        underline="hover"
                       >
                         <label className="ProposalCard__head__description--tier">
                           {props.tierName}
                         </label>
-                      </StyledLink>
+                      </Link>
                       <label
                         className="ProposalCard__head__description--tier--extra"
                         title="Maturation framework for innovation projects"


### PR DESCRIPTION
# What does this PR do?

This PR solves this bug we have in the Tiers link from the Proposal Card, it opens as a relative path but it is a link to an external URL

# Where should the reviewer start?

Go to the projects page.

# How should this be manually tested?

Go to the Projects page and click on any of the Tiers links from any proposal Card

# Any background context you want to provide?

As explained in this [thread](https://github.com/remix-run/react-router/discussions/8611), we shouldn't use `<Link />` component when referring to external URLs, in this case a simple `<a>` tag is good enough.

# What are the relevant tickets?

#105 

# Checklist

<!-- Verify that you have done all of the following and mark them as done. -->

- [ ] I added the necessary documentation, if appropriate.
- [ ] I added tests to prove that my fix is effective or my feature works.
- [X] I reviewed existing Pull Requests before submitting mine.