### PR TITLE
feat: add links to project search to project view fields

### DIFF
--- a/app/routes/projects/$projectId/index.tsx
+++ b/app/routes/projects/$projectId/index.tsx
@@ -28,7 +28,10 @@ import {
   CardHeader,
   Link,
 } from "@mui/material";
-import { EditSharp, ThumbUpSharp, ThumbDownSharp } from "@mui/icons-material";
+import EditSharp from "@mui/icons-material/EditSharp";
+import ThumbUpSharp from "@mui/icons-material/ThumbUpSharp";
+import ThumbDownSharp from "@mui/icons-material/ThumbDownSharp";
+import OpenInNew from "@mui/icons-material/OpenInNew";
 import { adminRoleName } from "app/constants";
 import ContributorPathReport from "../../../core/components/ContributorPathReport/index";
 import { useEffect, useState } from "react";
@@ -46,6 +49,7 @@ import Comments from "~/core/components/Comments";
 
 import MDEditorStyles from "@uiw/react-md-editor/markdown-editor.css";
 import MarkdownStyles from "@uiw/react-markdown-preview/markdown.css";
+import RemixLink from "~/core/components/Link";
 
 export function links() {
   return [
@@ -252,7 +256,12 @@ export default function ProjectDetailsPage() {
                 <div className="itemHeadName">Status:</div>{" "}
               </Grid>
               <Grid item>
-                <div className="itemHeadValue">{project.status}</div>
+                <RemixLink
+                  className="itemHeadValue"
+                  to={`/projects?status=${project.status}`}
+                >
+                  {project.status}
+                </RemixLink>
               </Grid>
             </Grid>
             <Grid
@@ -261,15 +270,31 @@ export default function ProjectDetailsPage() {
               sm={6}
               xs={12}
               spacing={1}
-              alignItems="center"
+              alignItems="end"
               justifyContent="flex-start"
               direction={{ xs: "column", md: "row" }}
             >
               <Grid item>
-                <div className="itemHeadName">Tier:</div>{" "}
+                <Link
+                  className="itemHeadName"
+                  target="_blank"
+                  rel="noreferrer"
+                  href="https://wizeline.atlassian.net/wiki/spaces/wiki/pages/3075342381/Innovation+Tiers"
+                >
+                  <b>Innovation Tier</b>
+                  <sup>
+                    <OpenInNew style={{ fontSize: 10 }} />
+                  </sup>
+                </Link>{" "}
+                :
               </Grid>
               <Grid item>
-                <div className="itemHeadValue">{project.tierName}</div>
+                <RemixLink
+                  className="itemHeadValue"
+                  to={`/projects?tier=${project.tierName}`}
+                >
+                  {project.tierName}
+                </RemixLink>
               </Grid>
             </Grid>
             <Grid
@@ -290,34 +315,13 @@ export default function ProjectDetailsPage() {
                   project.labels.map((item, index) => (
                     <Chip
                       key={index}
+                      component="a"
+                      href={`/projects?label=${item.name}`}
+                      clickable
                       label={item.name}
                       sx={{ marginRight: 1, marginBottom: 1 }}
                     />
                   ))}
-              </Grid>
-            </Grid>
-
-            <Grid
-              item
-              container
-              sm={6}
-              xs={12}
-              spacing={1}
-              alignItems="center"
-              justifyContent="flex-start"
-              direction={{ xs: "column", md: "row" }}
-            >
-              <Grid item>
-                <div className="itemHeadName">Innovation Tier:</div>
-              </Grid>
-              <Grid item>
-                <Link
-                  target="_blank"
-                  rel="noreferrer"
-                  href="https://wizeline.atlassian.net/wiki/spaces/wiki/pages/3075342381/Innovation+Tiers"
-                >
-                  {project.tierName}
-                </Link>
               </Grid>
             </Grid>
           </Grid>
@@ -365,9 +369,15 @@ export default function ProjectDetailsPage() {
                 <Card>
                   <CardHeader title="Slack Channel:" />
                   <CardContent>
-                    <Stack direction="row" spacing={1}>
+                    <Link
+                      target="_blank"
+                      href={`https://wizeline.slack.com/channels/${project.slackChannel.replace(
+                        "#",
+                        ""
+                      )}`}
+                    >
                       {project.slackChannel}
-                    </Stack>
+                    </Link>
                   </CardContent>
                 </Card>
               )}
@@ -406,6 +416,9 @@ export default function ProjectDetailsPage() {
                     {project.skills.map((item, index) => (
                       <Chip
                         key={index}
+                        component="a"
+                        href={`/projects?skill=${item.name}`}
+                        clickable
                         label={item.name}
                         sx={{ marginRight: 1, marginBottom: 1 }}
                       />

--- a/app/routes/projects/$projectId/index.tsx
+++ b/app/routes/projects/$projectId/index.tsx
@@ -434,6 +434,9 @@ export default function ProjectDetailsPage() {
                       project.disciplines.map((item, index) => (
                         <Chip
                           key={index}
+                          component="a"
+                          href={`/projects?discipline=${item.name}`}
+                          clickable
                           label={item.name}
                           sx={{ marginRight: 1, marginBottom: 1 }}
                         />

--- a/app/routes/projects/index.tsx
+++ b/app/routes/projects/index.tsx
@@ -159,10 +159,10 @@ export default function Projects() {
     searchParams: ideasSearchParams,
   };
   const tabs: Tabs = {
-    "myProposals" : myProposalsTab,
-    "activeProjects": activeProjectsTab,
-    "ideas": ideasTab
-  }
+    myProposals: myProposalsTab,
+    activeProjects: activeProjectsTab,
+    ideas: ideasTab,
+  };
 
   const goToPreviousPage = () => {
     searchParams.set("page", String(page - 1));
@@ -239,8 +239,8 @@ export default function Projects() {
   const lessThanMd = useMediaQuery(theme.breakpoints.down("md"));
 
   const StyledTabButton = styled(Button)(({ theme }) => ({
-    fontWeight: 'bold',
-    color: theme.palette.mode === 'dark' ? '#fff' : theme.palette.primary.main,
+    fontWeight: "bold",
+    color: theme.palette.mode === "dark" ? "#fff" : theme.palette.primary.main,
   }));
 
   return (
@@ -258,10 +258,10 @@ export default function Projects() {
                 color="primary"
                 size="small"
                 disableElevation
-                variant={isTabActive(tab.name) ? 'contained' : 'text'}
+                variant={isTabActive(tab.name) ? "contained" : "text"}
                 onClick={() => handleTabChange(tab.name)}
                 key={tab.name}
-                sx={{ color: isTabActive(tab.name) ? '#fff' : null }}
+                sx={{ color: isTabActive(tab.name) ? "#fff" : null }}
               >
                 {tab.title}
               </StyledTabButton>

--- a/app/routes/projects/index.tsx
+++ b/app/routes/projects/index.tsx
@@ -439,7 +439,7 @@ export default function Projects() {
                     aria-controls="panel2a-controls"
                     id="panel2a-header"
                   >
-                    <strong>Roles</strong>
+                    <strong>Has Roles</strong>
                   </AccordionSummary>
                   <AccordionDetails>
                     <ul>
@@ -465,7 +465,7 @@ export default function Projects() {
                     aria-controls="panel2a-controls"
                     id="panel2a-header"
                   >
-                    <strong>Missing Roles</strong>
+                    <strong>Does not have Roles</strong>
                   </AccordionSummary>
                   <AccordionDetails>
                     <ul>

--- a/app/routes/projects/index.tsx
+++ b/app/routes/projects/index.tsx
@@ -42,7 +42,7 @@ const FACETS = [
   "status",
   "skill",
   "label",
-  "disciplines",
+  "discipline",
   "location",
   "tier",
   "role",


### PR DESCRIPTION
- make fields like labels, skills, status, etc in the project view page link to the corresponding project search page.
- make slack channel a link! Slack provides: `https://<space>.slack.com/channels/<channel-name>`
- fix `Looking for` filter on the projects search page
- change (improve?) labels for roles and missing roles:
   - Roles -> Has Roles
   - Missing Roles -> Does not have Roles

Closes #117

# Screenshots

![Screenshot 2023-01-18 at 12 26 05](https://user-images.githubusercontent.com/15214/213265498-df7a0b49-8e50-4f57-bfa1-afc8468a823a.png)

# Questions

<!-- List questions or concerns directed to the reviewers, if necessary. -->

# Checklist

<!-- Verify that you have done all of the following and mark them as done. -->

- [ ] I added the necessary documentation, if appropriate.
- [ ] I added tests to prove that my fix is effective or my feature works.
- [ ] I reviewed existing Pull Requests before submitting mine.