### PR TITLE
Feat - 144 - Inactivate members who left wizeline

### DIFF
--- a/app/lake.server.tsx
+++ b/app/lake.server.tsx
@@ -80,3 +80,31 @@ export async function getActiveProfiles() {
     throw new Error("Profile not found on lake");
   }
 }
+
+export async function getInactiveProfiles() {
+  const query = `SELECT contact__wizeos_profile_id, contact__employee_number, contact__email,
+    contact__first_name, contact__preferred_name, contact__last_name,
+    contact__photo__url,
+    contact__location, contact__country,
+    contact__status, contact__department, contact__business_unit,
+    contact__employee_status,
+    contact__wizeos__level, contact__title, contact__role
+  FROM \`wizelake-prod.wizelabs_wzlk.contact\`
+  WHERE contact__employee_status = "Terminated"`;
+
+  const options = {
+    query: query,
+    location: "US",
+    params: {},
+  };
+
+  // Wait for the query to finish
+  const [rows] = await client.query(options);
+
+  // Print the results
+  if (rows.length > 0) {
+    return rows;
+  } else {
+    throw new Error("No profiles found");
+  }
+}

--- a/app/models/profile.server.ts
+++ b/app/models/profile.server.ts
@@ -173,6 +173,36 @@ export async function consolidateProfilesByEmail(
   }
 }
 
+export async function terminateProfiles(
+  emails: string[],
+  db: PrismaClient
+) {
+  // don't do anything if we have no data (avoid Terminating users)
+  if (emails.length == 0) {
+    return;
+  }
+  // eslint-disable-next-line no-console
+  console.info(`Terminating inactive users in data lake DB`);
+
+  try {
+    const result = await db.profiles.updateMany({
+      data: {
+        employeeStatus: 'Terminated'
+      },
+      where: {
+        email: {
+          in: emails
+        }
+      }
+    })
+    // eslint-disable-next-line no-console
+    console.info(`${result.count} affected profiles`);
+  } catch (e) {
+    // eslint-disable-next-line no-console
+    console.log(e);
+  }
+}
+
 export async function searchProfiles(searchTerm: string) {
   const select = Prisma.sql`
     SELECT id, "preferredName" || ' ' || "lastName" || ' <' || "email" || '>' as name

--- a/app/terminateProfiles.server.ts
+++ b/app/terminateProfiles.server.ts
@@ -1,0 +1,14 @@
+import type { PrismaClient } from "@prisma/client";
+import { getInactiveProfiles } from "./lake.server";
+import { terminateProfiles } from "./models/profile.server";
+
+async function getProfilesToTerminate(): Promise<string[]> {
+  const inactiveProfiles = await getInactiveProfiles();
+  return inactiveProfiles.filter(lakeProfile => lakeProfile.contact__email !== null && lakeProfile.contact__email.length > 0).map(lakeProfile => lakeProfile.contact__email);
+}
+
+export async function terminateInactiveProfiles(db: PrismaClient) {
+  const inactiveProfiles = await getProfilesToTerminate();
+  // const inactiveProfiles = ['test@wizeline.com', 'mauricio.barragan@wizeline.com']
+  terminateProfiles(inactiveProfiles, db);
+}

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "typecheck": "tsc -b && tsc -b cypress",
     "validate": "run-p \"test -- --run\" lint typecheck test:e2e:run",
     "migrate-profiles-lake": "ts-node --project ./ts-node.tsconfig.json ./tasks/ProfilesMigration/migrateProfilesLake.ts",
+    "terminate-inactive-profiles": "ts-node --project ./ts-node.tsconfig.json ./tasks/terminateProfiles.ts",
     "prepare": "husky install"
   },
   "eslintIgnore": [

--- a/tasks/terminateProfiles.ts
+++ b/tasks/terminateProfiles.ts
@@ -1,0 +1,16 @@
+import { PrismaClient } from "@prisma/client";
+import { terminateInactiveProfiles } from "../app/terminateProfiles.server";
+
+const db = new PrismaClient();
+
+async function task() {
+    console.info(`Loading configuration`);
+    await terminateInactiveProfiles(db);
+    console.info(`Task finished successfully`);
+}
+
+//close connection
+task().finally(() => {
+    console.info(`Disconnecting DB connection`);
+    db.$disconnect();
+});


### PR DESCRIPTION
# What does this PR do?

Adds a script to terminate profiles for users that are inactive in Data Lake

# Where should the reviewer start?

- app/lake.server.tsx
- app/models/profile.server.ts

# How should this be manually tested?

Execute the following command on the root of the project:

`npm run terminate-inactive-profiles`

# Any background context you want to provide?

<!-- Add any information regarding the PR that the reviewers should know, if necessary. -->

# What are the relevant tickets?

[Ticket 144](https://github.com/wizeline/remix-project-lab/issues/144)

# Screenshots

<!-- Add before and after screenshots or recording of the feature, if available. -->

# Questions

<!-- List questions or concerns directed to the reviewers, if necessary. -->

# Checklist

<!-- Verify that you have done all of the following and mark them as done. -->

- [ ] I added the necessary documentation, if appropriate.
- [ ] I added tests to prove that my fix is effective or my feature works.
- [ ] I reviewed existing Pull Requests before submitting mine.