### PR TITLE
[144] Fix terminated users not found on data lake DB

### DIFF
--- a/app/models/profile.server.ts
+++ b/app/models/profile.server.ts
@@ -163,9 +163,18 @@ export async function consolidateProfilesByEmail(
       });
       // eslint-disable-next-line no-console
       console.info(`Terminate users not found on data lake from DB`);
-      db.$queryRaw`UPDATE "Profiles" SET "employeeStatus"='Terminated' WHERE email NOT IN (${Prisma.join(
-        profileMails
-      )})`;
+      const result = await db.profiles.updateMany({
+        data: {
+          employeeStatus: 'Terminated'
+        },
+        where: {
+          email: {
+            notIn: profileMails
+          }
+        }
+      })
+      // eslint-disable-next-line no-console
+      console.info(`${result.count} affected profiles`);
     });
   } catch (e) {
     // eslint-disable-next-line no-console


### PR DESCRIPTION
# What does this PR do?

Fixes the script that updates users with data from Datalake. This PR fixes the part that terminates the users not found in Data lake which was not working before

# Where should the reviewer start?

app/models/profile.server.ts

# How should this be manually tested?

Run in the terminal on the root of the project:
`npm run migrate-profiles-lake`


# What are the relevant tickets?

[Ticket 144](https://github.com/wizeline/remix-project-lab/issues/144)

# Screenshots

<!-- Add before and after screenshots or recording of the feature, if available. -->

# Questions

<!-- List questions or concerns directed to the reviewers, if necessary. -->

# Checklist

<!-- Verify that you have done all of the following and mark them as done. -->

- [ ] I added the necessary documentation, if appropriate.
- [ ] I added tests to prove that my fix is effective or my feature works.
- [ ] I reviewed existing Pull Requests before submitting mine.