### PR TITLE
Feat - 188 - Resource/Provider Filter for projects screen

### DIFF
--- a/app/core/components/MembershipModal/index.tsx
+++ b/app/core/components/MembershipModal/index.tsx
@@ -1,83 +1,56 @@
 import { FieldArray, ValidatedForm } from "remix-validated-form";
 import ModalBox from "../ModalBox/index";
-import {
-  Accordion,
-  AccordionDetails,
-  AccordionSummary,
-  Button,
-  Card,
-  CardContent,
-  CardHeader,
-  Grid,
-  Typography,
-} from "@mui/material";
+import { Accordion, AccordionDetails, AccordionSummary, Button, Card, CardContent, CardHeader, Grid, Typography } from "@mui/material";
 import DisciplinesSelect from "~/core/components/DisciplinesSelect";
 import LabeledTextField from "~/core/components/LabeledTextField";
 import SkillsSelect from "~/core/components/SkillsSelect";
 import { withZod } from "@remix-validated-form/with-zod";
 import { z } from "zod";
 import { zfd } from "zod-form-data";
-import { ModalText } from "./MemberModal.styles";
+import { ModalText} from "./MemberModal.styles";
+import type { projectMembership } from "~/routes/projects";
 import { LabeledCheckbox } from "../LabeledCheckbox";
 import { Fragment } from "react";
-import ExpandMoreIcon from "@mui/icons-material/ExpandMore";
-
-interface projectMembership {
-  active: boolean;
-  createdAt: Date;
-  hoursPerWeek: number | null;
-  id: string;
-  practicedSkills: {
-    id: string;
-    name: string;
-  }[];
-  profileId: string;
-  project: { name: string };
-  projectId: string;
-  role: {
-    id: string;
-    name: string;
-  }[];
-  updatedAt: Date;
-}
+import ExpandMoreIcon from '@mui/icons-material/ExpandMore';
 
 interface IProps {
   open: boolean;
   handleCloseModal: Function;
-  projects: projectMembership[];
+  projects:projectMembership[];
 }
 
-export const multipleProjectsValidator = withZod(
+export const multipleProjectsValidator = withZod (
   zfd.formData({
     projects: z.array(
-      z.object({
-        id: z.string(),
-        hoursPerWeek: zfd.numeric(z.number()).nullable(),
-        role: z.array(
-          z.object({
-            id: z.string(),
-            name: z.string().optional(),
-          })
-        ),
-        practicedSkills: z.array(
-          z.object({
-            id: z.string(),
-            name: z.string().optional(),
-          })
-        ),
-        active: zfd.checkbox(),
-        profileId: z.string(),
-        projectId: z.string(),
+        z.object({
+          id: z.string(),
+          hoursPerWeek: zfd.numeric(z.number()),
+          role: z
+            .array(
+              z.object({
+                id: z.string(),
+                name: z.string().optional(),
+              })
+            ),
+          practicedSkills: z
+            .array(
+              z.object({
+                id: z.string(),
+                name: z.string().optional(),
+              })
+            ),
+            active: zfd.checkbox(),
+            profileId: z.string(),
+            projectId: z.string(),
+        })
+      ),
       })
-    ),
-  })
 );
 
-export const validator = withZod(
-  //this is the same of join project
+export const validator = withZod( //this is the same of join project
   zfd.formData({
     id: z.string(),
-    hoursPerWeek: zfd.numeric(z.number().optional()).nullable(),
+    hoursPerWeek: zfd.numeric(z.number().optional()),
     role: z
       .array(
         z.object({
@@ -94,14 +67,14 @@ export const validator = withZod(
         })
       )
       .optional(),
-    active: zfd.checkbox(),
-    profileId: z.string(),
-    projectId: z.string(),
+      active: zfd.checkbox(),
+      profileId: z.string(),
+      projectId: z.string(),
   })
 );
 
 const MembershipModal = (props: IProps) => {
-  const { projects } = props;
+  const{ projects } = props;
   let projectsCount = projects.length;
 
   return (
@@ -111,203 +84,223 @@ const MembershipModal = (props: IProps) => {
       handleClose={() => {}}
       boxStyle={{ width: "950px" }}
     >
-      <ModalText>
-        Hey!, it seems like you haven't been involved in these projects in a
-        while. Are you still working on it?
-      </ModalText>
-      {projectsCount == 1 &&
-        projects.map((project, id) => {
-          return (
-            <Grid key={id}>
-              <Card>
-                <CardHeader title={project.project?.name} />
-                <CardContent>
-                  <ValidatedForm
-                    validator={validator}
-                    defaultValues={{
-                      hoursPerWeek: project.hoursPerWeek,
-                      role: project.role,
-                      practicedSkills: project.practicedSkills,
-                      active: project.active,
-                      id: project.id,
-                      profileId: project.profileId,
-                    }}
-                    method="post"
-                    action="./singleManageMembership"
-                  >
-                    <input type="hidden" name="id" value={project.id} />
-                    <input
-                      type="hidden"
-                      name="profileId"
-                      value={project.profileId}
+        <ModalText>
+          Hey!, it seems like you haven't been involved in these projects in a
+          while. Are you still working on it?
+        </ModalText>
+        { 
+          projectsCount == 1 && projects.map((project, id) => {
+            return (
+                <Grid key={id}>
+                  <Card>
+                    <CardHeader 
+                      title={project.project?.name}
                     />
-                    <input
-                      type="hidden"
-                      name="projectId"
-                      value={project.projectId}
-                    />
-                    <Grid
-                      container
-                      spacing={1}
-                      alignItems="baseline"
-                      rowSpacing={{ xs: 2, sm: 2 }}
-                      style={{ paddingTop: 20 }}
-                      justifyContent="space-evenly"
-                    >
-                      <Grid item xs={6} sm={1}>
-                        <LabeledTextField
-                          label="Hours"
-                          helperText="H. per week"
-                          name={`hoursPerWeek`}
-                          size="small"
-                          type="number"
-                          sx={{
-                            "& .MuiFormHelperText-root": {
-                              marginLeft: 0,
-                              marginRight: 0,
-                              textAlign: "center",
-                            },
+                    <CardContent>
+                      <ValidatedForm
+                          validator={ validator }
+                          defaultValues={{
+                            hoursPerWeek: project.hoursPerWeek,
+                            role: project.role,
+                            practicedSkills: project.practicedSkills,
+                            active: project.active,
+                            id: project.id,
+                            profileId: project.profileId
                           }}
-                        />
-                      </Grid>
-
-                      <Grid item xs={12} sm={4}>
-                        <DisciplinesSelect //still uses constant values instead of values taken from the db
-                          name="role"
-                          label="Role(s)"
-                        />
-                      </Grid>
-
-                      <Grid item xs={12} sm={4}>
-                        <SkillsSelect //still uses constant values instead of values taken from the db
-                          name="practicedSkills"
-                          label="Skills"
-                        />
-                      </Grid>
-
-                      <Grid item xs={2} sm={1}>
-                        <LabeledCheckbox name="active" label="Active" />
-                      </Grid>
-                    </Grid>
-                    <Grid
-                      container
-                      direction="row"
-                      justifyContent="flex-end"
-                      alignItems="flex-end"
-                    >
-                      <Button type="submit" variant="contained">
-                        Save
-                      </Button>
-                    </Grid>
-                  </ValidatedForm>
-                </CardContent>
-              </Card>
-            </Grid>
-          );
-        })}
-      {projectsCount > 1 && (
-        <Grid>
-          <ValidatedForm
-            defaultValues={{
-              projects: projects,
-            }}
-            validator={multipleProjectsValidator}
-            action="./manageMembership"
-            method="post"
-          >
-            <FieldArray name="projects">
-              {(items, { push, remove }) => (
-                <>
-                  {items.map((item, i) => (
-                    <Accordion key={i}>
-                      <AccordionSummary
-                        expandIcon={<ExpandMoreIcon />}
-                        aria-controls="panel1a-content"
-                        id="panel1a-header"
-                      >
-                        <Typography>{item.project.name}</Typography>
-                      </AccordionSummary>
-                      <AccordionDetails>
-                        <input
-                          type="hidden"
-                          name={`projects[${i}].id`}
-                          value={item.id}
-                        />
-                        <input
-                          type="hidden"
-                          name={`projects[${i}].profileId`}
-                          value={item.profileId}
-                        />
-                        <input
-                          type="hidden"
-                          name={`projects[${i}].projectId`}
-                          value={item.projectId}
-                        />
-                        <Grid
-                          container
-                          spacing={1}
-                          alignItems="baseline"
-                          rowSpacing={{ xs: 2, sm: 2 }}
-                          style={{ paddingTop: 20 }}
-                          justifyContent="space-evenly"
+                          method="post"
+                          action="./singleManageMembership"
                         >
-                          <Grid item xs={6} sm={1}>
-                            <LabeledTextField
-                              label="Hours"
-                              helperText="H. per week"
-                              name={`projects[${i}].hoursPerWeek`}
-                              size="small"
-                              type="number"
-                              sx={{
-                                "& .MuiFormHelperText-root": {
-                                  marginLeft: 0,
-                                  marginRight: 0,
-                                  textAlign: "center",
-                                },
-                              }}
-                            />
-                          </Grid>
+                          <input
+                            type="hidden"
+                            name="id"
+                            value={project.id}
+                          />
+                          <input
+                            type="hidden"
+                            name="profileId"
+                            value={project.profileId}
+                          />
+                          <input
+                            type="hidden"
+                            name="projectId"
+                            value={project.projectId}
+                          />
+                          <Grid
+                            container
+                            spacing={1}
+                            alignItems="baseline"
+                            rowSpacing={{ xs: 2, sm: 2 }}
+                            style={{ paddingTop: 20 }}
+                            justifyContent="space-evenly"
+                          >
+                            <Grid item xs={6} sm={1}>
+                              <LabeledTextField
+                                label="Hours"
+                                helperText="H. per week"
+                                name={`hoursPerWeek`}
+                                size="small"
+                                type="number"
+                                sx={{
+                                  "& .MuiFormHelperText-root": {
+                                    marginLeft: 0,
+                                    marginRight: 0,
+                                    textAlign: "center",
+                                  },
+                                }}
+                              />
+                            </Grid>
 
-                          <Grid item xs={12} sm={4}>
-                            <DisciplinesSelect //still uses constant values instead of values taken from the db
-                              name={`projects[${i}].role`}
-                              label="Role(s)"
-                            />
-                          </Grid>
+                            <Grid item xs={12} sm={4}>
+                              <DisciplinesSelect //still uses constant values instead of values taken from the db
+                                name="role"
+                                label="Role(s)"
+                              />
+                            </Grid>  
+                              
+                            <Grid item xs={12} sm={4}>
+                              <SkillsSelect //still uses constant values instead of values taken from the db
+                                name="practicedSkills"
+                                label="Skills"
+                              />
+                            </Grid>
 
-                          <Grid item xs={12} sm={4}>
-                            <SkillsSelect //still uses constant values instead of values taken from the db
-                              name={`projects[${i}].practicedSkills`}
-                              label="Skills"
-                            />
-                          </Grid>
+                            <Grid
+                              item
+                              xs={2}
+                              sm={1}
+                              
+                            >
+                              <LabeledCheckbox
+                                name="active"
+                                label="Active"
+                              />
+                            </Grid>
 
-                          <Grid item xs={2} sm={1}>
-                            <LabeledCheckbox
-                              name={`projects[${i}].active`}
-                              label="Active"
-                            />
                           </Grid>
-                        </Grid>
-                      </AccordionDetails>
-                    </Accordion>
-                  ))}
-                </>
-              )}
-            </FieldArray>
-            <Grid
-              container
-              direction="row"
-              justifyContent="flex-end"
-              alignItems="flex-end"
-            >
-              <Button type="submit" variant="contained">
-                Save
-              </Button>
+                          <Grid container direction="row"
+                                justifyContent="flex-end"
+                                alignItems="flex-end">   
+                            <Button type="submit" variant="contained">
+                              Save
+                            </Button>
+                          </Grid>
+                        </ValidatedForm>
+                    </CardContent>
+                  </Card>
+                </Grid>
+            )
+          })
+        }
+        {
+          projectsCount > 1 && (
+            <Grid>
+              <ValidatedForm 
+                defaultValues={{
+                  projects: projects
+                }}
+                validator={multipleProjectsValidator} 
+                action="./manageMembership"
+                method="post"
+              >
+                    
+                <FieldArray name="projects">
+                  {
+                    (items, { push, remove }) => (
+                      <>
+                        {
+                          items.map((item, i) => (
+                            <Accordion key={i}>
+                              <AccordionSummary
+                                expandIcon={<ExpandMoreIcon />}
+                                aria-controls="panel1a-content"
+                                id="panel1a-header"
+                              >
+                                <Typography>{item.project.name}</Typography>
+                              </AccordionSummary>
+                              <AccordionDetails>
+                              <input
+                                type="hidden"
+                                name={`projects[${i}].id`}
+                                value={item.id}
+                              />
+                              <input
+                                type="hidden"
+                                name={`projects[${i}].profileId`}
+                                value={item.profileId}
+                              />
+                              <input
+                                type="hidden"
+                                name={`projects[${i}].projectId`}
+                                value={item.projectId}
+                              />
+                                <Grid
+                                  container
+                                  spacing={1}
+                                  alignItems="baseline"
+                                  rowSpacing={{ xs: 2, sm: 2 }}
+                                  style={{ paddingTop: 20 }}
+                                  justifyContent="space-evenly"
+                                >
+                                  <Grid item xs={6} sm={1}>
+                                    <LabeledTextField
+                                      label="Hours"
+                                      helperText="H. per week"
+                                      name={`projects[${i}].hoursPerWeek`}
+                                      size="small"
+                                      type="number"
+                                      sx={{
+                                          "& .MuiFormHelperText-root": {
+                                            marginLeft: 0,
+                                            marginRight: 0,
+                                            textAlign: "center",
+                                          },
+                                      }}
+                                    />
+                                  </Grid>
+
+                                  <Grid item xs={12} sm={4}>
+                                    <DisciplinesSelect //still uses constant values instead of values taken from the db
+                                      name={`projects[${i}].role`}
+                                      label="Role(s)"
+                                    />
+                                  </Grid>  
+                                      
+                                  <Grid item xs={12} sm={4}>
+                                    <SkillsSelect //still uses constant values instead of values taken from the db
+                                      name={`projects[${i}].practicedSkills`}
+                                      label="Skills"
+                                    />
+                                  </Grid>
+
+                                  <Grid item xs={2} sm={1}>
+                                    <LabeledCheckbox
+                                      name={`projects[${i}].active`}
+                                      label="Active"
+                                    />
+                                  </Grid>
+                                </Grid>
+                              </AccordionDetails>
+                            </Accordion>
+                          ))
+                        }
+                      </>
+                    )
+                  }
+                </FieldArray>
+                <Grid container direction="row"
+                  justifyContent="flex-end"
+                  alignItems="flex-end">   
+                    <Button type="submit" variant="contained">
+                      Save
+                    </Button>
+                </Grid>
+              </ValidatedForm>
             </Grid>
-          </ValidatedForm>
-        </Grid>
-      )}
+
+          )
+        }
+       
+
     </ModalBox>
   );
 };

--- a/app/core/components/ProposalCard/ProposalCard.styles.tsx
+++ b/app/core/components/ProposalCard/ProposalCard.styles.tsx
@@ -4,6 +4,7 @@ export const ProposalCardWrap = styled.div`
   display: flex;
   flex-direction: column;
   position: relative;
+  font-size: 1rem;
 
   .ProposalCard__head {
     display: flex;
@@ -72,6 +73,7 @@ export const ProposalCardWrap = styled.div`
     }
   }
   .ProposalCard__status--display {
+    font-size: 1rem;
     height: 25px;
     font-weight: 700;
     line-height: 25px;

--- a/app/core/components/ProposalCard/index.tsx
+++ b/app/core/components/ProposalCard/index.tsx
@@ -11,6 +11,7 @@ import ThumbUpIcon from "@mui/icons-material/ThumbUp";
 import PersonIcon from "@mui/icons-material/Person";
 import HelpIcon from "@mui/icons-material/Help";
 import { ProposalCardWrap } from "./ProposalCard.styles";
+import { useNavigate } from "@remix-run/react";
 
 interface IProps {
   id: string | number;
@@ -29,15 +30,20 @@ interface IProps {
 }
 
 export const ProposalCard = (props: IProps) => {
+  const navigate = useNavigate();
   const stopEvent = (event: React.MouseEvent<HTMLElement>) =>
     event.stopPropagation();
 
   const prefersDarkMode = useMediaQuery("(prefers-color-scheme: dark)");
 
+  const handleCardClick = () => {
+    navigate(`/projects/${props.id}`);
+  };
+
   return (
     <>
       <Card>
-        <CardActionArea sx={{ height: "100%" }} href={`/projects/${props.id}`}>
+        <CardActionArea sx={{ height: "100%" }} onClick={handleCardClick}>
           <CardContent>
             <ProposalCardWrap>
               <div className="ProposalCard__head">

--- a/app/models/project.server.ts
+++ b/app/models/project.server.ts
@@ -767,7 +767,7 @@ export async function searchProjects({
   `;
 
   const resourceFacets = await db.$queryRaw<FacetOutput[]>`
-    SELECT DISTINCT r.type as name, count(DISTINCT r.type) as count
+    SELECT DISTINCT r.type as name, count(DISTINCT r.id) as count
     FROM "Projects" p
     LEFT JOIN "Resource" r ON p."id" = r."projectId"
     WHERE ${projectIdsWhere} AND r.type NOT IN (${resource.length > 0 ? Prisma.join(resource) : ""
@@ -783,24 +783,24 @@ export async function searchProjects({
       const valuePairs = provider.map(value => value.split(' | '))
       const joined = valuePairs.map(pair => Prisma.join(pair))
       providerFacets = await db.$queryRaw<FacetOutput[]>`
-      SELECT r.type || ' | ' || r.provider as name, r.id, count(DISTINCT p.id) as count
+      SELECT r.type || ' | ' || r.provider as name, count(DISTINCT p.id) as count
       FROM "Projects" p
       LEFT JOIN "Resource" r ON p."id" = r."projectId"
       WHERE ${projectIdsWhere} AND (r.type,r.provider) NOT IN (VALUES (${Prisma.join(joined, "),(")})) AND r.type IN (${Prisma.join(resource)})
       AND r.provider IS NOT NULL
       AND r.id IS NOT NULL
-      GROUP BY r.id
+      GROUP BY r.type, r.provider
       ORDER BY count DESC
     `;
     } else {
       providerFacets = await db.$queryRaw<FacetOutput[]>`
-      SELECT r.type || ' | ' || r.provider as name, r.id, count(DISTINCT p.id) as count
+      SELECT r.type || ' | ' || r.provider as name, count(DISTINCT p.id) as count
       FROM "Projects" p
       LEFT JOIN "Resource" r ON p."id" = r."projectId"
       WHERE ${projectIdsWhere} AND r.type IN (${Prisma.join(resource)})
       AND r.provider IS NOT NULL
       AND r.id IS NOT NULL
-      GROUP BY r.id
+      GROUP BY r.type, r.provider
       ORDER BY count DESC
     `;
     }

--- a/app/models/project.server.ts
+++ b/app/models/project.server.ts
@@ -767,14 +767,13 @@ export async function searchProjects({
   `;
 
   const resourceFacets = await db.$queryRaw<FacetOutput[]>`
-    SELECT r.type as name, r.id, count(DISTINCT p.id) as count
+    SELECT DISTINCT r.type as name, count(DISTINCT r.type) as count
     FROM "Projects" p
     LEFT JOIN "Resource" r ON p."id" = r."projectId"
     WHERE ${projectIdsWhere} AND r.type NOT IN (${resource.length > 0 ? Prisma.join(resource) : ""
     })
     AND r.type IS NOT NULL
-    AND r.id IS NOT NULL
-    GROUP BY r.id
+    GROUP BY r.type
     ORDER BY count DESC
   `;
 

--- a/app/models/project.server.ts
+++ b/app/models/project.server.ts
@@ -522,11 +522,12 @@ export async function updateRelatedProjects({
   });
 }
 
+
 export async function getProjectMembership(profileId: string) {
   let daysToCheck = 30;
   let limitDateAbsence = new Date();
   limitDateAbsence.setDate(limitDateAbsence.getDate() - daysToCheck);
-  return await db.projectMembers.findMany({
+  let queryMembership = await db.projectMembers.findMany({
     where: {
       profileId,
       updatedAt: {
@@ -538,23 +539,23 @@ export async function getProjectMembership(profileId: string) {
       practicedSkills: true,
       role: true,
       project: {
-        select: { name: true },
-      },
-    },
-  });
+        select: { name: true }
+      }
+    }
+  }
+  );
+  return queryMembership;
 }
 
-export async function updateProjectActivity(
-  projects: {
-    id: string;
-    profileId: string;
-    projectId: string;
-    hoursPerWeek?: number;
-    role: { id: string }[];
-    practicedSkills: { id: string }[];
-    active: boolean;
-  }[]
-) {
+export async function updateProjectActivity(projects: {
+  id: string;
+  profileId: string,
+  projectId: string,
+  hoursPerWeek?: number;
+  role: { id: string }[];
+  practicedSkills: { id: string }[];
+  active: boolean;
+}[]) {
   for (let i = 0; i < projects.length; i++) {
     await db.projectMembers.update({
       where: { id: projects[i].id as string },
@@ -570,6 +571,7 @@ export async function updateProjectActivity(
       },
     });
   }
+
 }
 
 export async function searchProjects({
@@ -587,7 +589,7 @@ export async function searchProjects({
   skip = 0,
   take = 50,
   resource,
-  provider,
+  provider
 }: SearchProjectsInput) {
   let where = Prisma.sql`WHERE p.id IS NOT NULL`;
   let having = Prisma.empty;
@@ -645,14 +647,12 @@ export async function searchProjects({
 
   if (resource.length > 0) {
     if (provider.length > 0) {
-      const valuePairs = provider.map((value) => value.split(" | "));
-      const joined = valuePairs.map((pair) => Prisma.join(pair));
+      const valuePairs = provider.map(value => value.split(' | '))
+      const joined = valuePairs.map(pair => Prisma.join(pair))
 
-      where = Prisma.sql`${where} AND (r.type, r.provider) IN (VALUES (${Prisma.join(
-        joined,
-        "),("
-      )}))`;
-    } else {
+      where = Prisma.sql`${where} AND (r.type, r.provider) IN (VALUES (${Prisma.join(joined, "),(")}))`
+    }
+    else {
       where = Prisma.sql`${where} AND r.type IN (${Prisma.join(resource)})`;
     }
   }
@@ -748,9 +748,8 @@ export async function searchProjects({
   const statusFacets = await db.$queryRaw<FacetOutput[]>`
     SELECT p.status as name, COUNT(DISTINCT p.id) as count
     FROM "Projects" p
-    WHERE ${projectIdsWhere} AND p.status NOT IN (${
-    status.length > 0 ? Prisma.join(status) : ""
-  })
+    WHERE ${projectIdsWhere} AND p.status NOT IN (${status.length > 0 ? Prisma.join(status) : ""
+    })
     GROUP BY p.status
     ORDER BY count DESC;`;
 
@@ -759,9 +758,8 @@ export async function searchProjects({
     FROM "Projects" p
     LEFT JOIN "_ProjectsToSkills" _ps ON _ps."A" = p.id
     LEFT JOIN "Skills" ON _ps."B" = "Skills".id
-    WHERE ${projectIdsWhere} AND "Skills".name NOT IN (${
-    skill.length > 0 ? Prisma.join(skill) : ""
-  })
+    WHERE ${projectIdsWhere} AND "Skills".name NOT IN (${skill.length > 0 ? Prisma.join(skill) : ""
+    })
     AND "Skills".name IS NOT NULL
     AND "Skills".id IS NOT NULL
     GROUP BY "Skills".id
@@ -772,27 +770,23 @@ export async function searchProjects({
     SELECT DISTINCT r.type as name, count(DISTINCT r.id) as count
     FROM "Projects" p
     LEFT JOIN "Resource" r ON p."id" = r."projectId"
-    WHERE ${projectIdsWhere} AND r.type NOT IN (${
-    resource.length > 0 ? Prisma.join(resource) : ""
-  })
+    WHERE ${projectIdsWhere} AND r.type NOT IN (${resource.length > 0 ? Prisma.join(resource) : ""
+    })
     AND r.type IS NOT NULL
     GROUP BY r.type
     ORDER BY count DESC
   `;
 
-  let providerFacets: FacetOutput[] = [];
+  let providerFacets: FacetOutput[] = []
   if (resource.length > 0) {
     if (provider.length > 0) {
-      const valuePairs = provider.map((value) => value.split(" | "));
-      const joined = valuePairs.map((pair) => Prisma.join(pair));
+      const valuePairs = provider.map(value => value.split(' | '))
+      const joined = valuePairs.map(pair => Prisma.join(pair))
       providerFacets = await db.$queryRaw<FacetOutput[]>`
       SELECT r.type || ' | ' || r.provider as name, count(DISTINCT p.id) as count
       FROM "Projects" p
       LEFT JOIN "Resource" r ON p."id" = r."projectId"
-      WHERE ${projectIdsWhere} AND (r.type,r.provider) NOT IN (VALUES (${Prisma.join(
-        joined,
-        "),("
-      )})) AND r.type IN (${Prisma.join(resource)})
+      WHERE ${projectIdsWhere} AND (r.type,r.provider) NOT IN (VALUES (${Prisma.join(joined, "),(")})) AND r.type IN (${Prisma.join(resource)})
       AND r.provider IS NOT NULL
       AND r.id IS NOT NULL
       GROUP BY r.type, r.provider
@@ -817,9 +811,8 @@ export async function searchProjects({
     FROM "Projects" p
     LEFT JOIN "_DisciplinesToProjects" _dp ON _dp."B" = p.id
     LEFT JOIN "Disciplines" ON _dp."A" = "Disciplines".id
-    WHERE ${projectIdsWhere} AND "Disciplines".name NOT IN (${
-    discipline.length > 0 ? Prisma.join(discipline) : ""
-  })
+    WHERE ${projectIdsWhere} AND "Disciplines".name NOT IN (${discipline.length > 0 ? Prisma.join(discipline) : ""
+    })
     AND "Disciplines".name IS NOT NULL
     AND "Disciplines".id IS NOT NULL
     GROUP BY "Disciplines".id
@@ -831,9 +824,8 @@ export async function searchProjects({
     FROM "Projects" p
     LEFT JOIN "_LabelsToProjects" _lp ON _lp."B" = p.id
     LEFT JOIN "Labels" ON _lp."A" = "Labels".id
-    WHERE ${projectIdsWhere} AND "Labels".name NOT IN (${
-    label.length > 0 ? Prisma.join(label) : ""
-  })
+    WHERE ${projectIdsWhere} AND "Labels".name NOT IN (${label.length > 0 ? Prisma.join(label) : ""
+    })
     AND "Labels".name IS NOT NULL
     AND "Labels".id IS NOT NULL
     GROUP BY "Labels".id
@@ -843,9 +835,8 @@ export async function searchProjects({
   const tierFacets = await db.$queryRaw<FacetOutput[]>`
     SELECT p."tierName" as name, COUNT(DISTINCT p.id) as count
     FROM "Projects" p
-    WHERE ${projectIdsWhere} AND p."tierName" NOT IN (${
-    tier.length > 0 ? Prisma.join(tier) : ""
-  })
+    WHERE ${projectIdsWhere} AND p."tierName" NOT IN (${tier.length > 0 ? Prisma.join(tier) : ""
+    })
     GROUP BY p."tierName"
     ORDER BY count DESC, p."tierName"
   `;
@@ -856,9 +847,8 @@ export async function searchProjects({
     INNER JOIN "ProjectMembers" pm ON pm."projectId" = p.id
     INNER JOIN "Profiles" pr on pr.id = p."ownerId"
     LEFT JOIN "Locations" loc ON loc.id = pr."locationId"
-    WHERE ${projectIdsWhere} AND loc.name NOT IN (${
-    location.length > 0 ? Prisma.join(location) : ""
-  })
+    WHERE ${projectIdsWhere} AND loc.name NOT IN (${location.length > 0 ? Prisma.join(location) : ""
+    })
     AND loc.name IS NOT NULL
     AND loc.id IS NOT NULL
     GROUP BY loc.id
@@ -929,5 +919,5 @@ export async function updateProjectResources(
 export async function getProjectsList() {
   return await db.$queryRaw<ProjectListOutput[]>`
    SELECT "id", "name" FROM "Projects" where "isArchived" = false
-  `;
+  `
 }


### PR DESCRIPTION
# What does this PR do?

Adds filters for Resource and Provider. The provider filter is only available if a Resource filter is selected first. This also means that if the Resource filter is cleared, the provider clear linked to that filter is cleared as well.

This also fixes an annoying warning that appeared on the browser console related to the ProposalCard rendering an `<a>` tag inside another `<a>` tag

# Where should the reviewer start?

app/models/project.server.ts
app/routes/projects/index.tsx

# How should this be manually tested?

Go to the Projects page
Add some resources to a project(s)
Look for the new `Resources` filter on the left side
Click on a resource filter and check that only shows projects with that type of resource.
After selecting a resource a second filter appears called `Provider`
Click a provider filter and check that the results are correct

# Any background context you want to provide?

<!-- Add any information regarding the PR that the reviewers should know, if necessary. -->

# What are the relevant tickets?

[Ticket 188](https://github.com/wizeline/remix-project-lab/issues/188)

# Screenshots

![image](https://github.com/wizeline/remix-project-lab/assets/75454591/dba5ac8e-7621-496d-8c82-e5aca3c2f8f2)

![image](https://github.com/wizeline/remix-project-lab/assets/75454591/825a26d5-c9cd-4e42-a960-875a08da01f1)

![image](https://github.com/wizeline/remix-project-lab/assets/75454591/c9f24755-de38-4ec9-8c9a-9381cb1ce547)


# Questions

<!-- List questions or concerns directed to the reviewers, if necessary. -->

# Checklist

<!-- Verify that you have done all of the following and mark them as done. -->

- [ ] I added the necessary documentation, if appropriate.
- [ ] I added tests to prove that my fix is effective or my feature works.
- [ ] I reviewed existing Pull Requests before submitting mine.