### PR TITLE
feat: change view of roles in contributors table

### DIFF
--- a/app/core/components/ContributorPathReport/index.tsx
+++ b/app/core/components/ContributorPathReport/index.tsx
@@ -19,6 +19,7 @@ import {
   TableRow,
   TableSortLabel,
   Button,
+  Chip,
 } from "@mui/material";
 import { useEffect, useState } from "react";
 
@@ -240,7 +241,20 @@ export const ContributorPathReport = ({ project, canEditProject }: IProps) => {
                           {row.name}
                         </Button>
                       </TableCell>
-                      <TableCell align="left">{row.role.join("\n")}</TableCell>
+                      <TableCell align="left" sx={{width: ""}}>
+                        {
+                          row.role.map((item, index) => (
+                            <Chip
+                              key={index}
+                              component="a"
+                              href={`/projects?role=${item}`}
+                              clickable
+                              label={item}
+                              sx={{ marginRight: 1, marginBottom: 1 }}
+                            />
+                          ))
+                        }
+                      </TableCell>
                       <TableCell align="center">
                         <Grid
                           container


### PR DESCRIPTION
<!-- PR title format: `<Feat|Bug|Test|Doc|Chore|Junk> - <tracker-number> - <Short description>` -->
<!-- Fill out this PR template to make it easier for reviewers to understand your code. Remove this comment and any unnecessary section. -->

# What does this PR do?
I made the roles clickable

<!-- Point out where the reviewer should start to review the code additions or subtractions. -->

# How should this be manually tested?

- Go to the list of contributors in the project
- Click on some roles

<!-- Add any information regarding the PR that the reviewers should know, if necessary. -->

# What are the relevant tickets?
#234 
<!-- Link to issues, related PRs, JIRA issues, etc. -->

# Screenshots
![image](https://github.com/wizeline/remix-project-lab/assets/74632242/1be43872-92e6-4e0e-85e7-fb2e651f7430)


<!-- Add before and after screenshots or recording of the feature, if available. -->

# Questions

<!-- List questions or concerns directed to the reviewers, if necessary. -->

# Checklist

<!-- Verify that you have done all of the following and mark them as done. -->

- [ ] I added the necessary documentation, if appropriate.
- [ ] I added tests to prove that my fix is effective or my feature works.
- [ ] I reviewed existing Pull Requests before submitting mine.