### PR TITLE
Feat - 194 - Admins and mentors can change applicant status from Accepted/Rejected to Hold/Draft

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,12 +62,13 @@ If you set a password in the installation of postgres, you should use this forma
 DATABASE_URL=postgresql://[username]:[password]@localhost:5432/[database]?schema=public
 ```
 
-2. Ask in `#team-wizelabs-io` channel on _Slack_
-   for the environment values for `.env` and access to the keybase team.
+2. Join [Keybase](https://keybase.io/) if you dont have an account yet.
 
-For the `GOOGLE_APPLICATION_CREDENTIALS=` there will be a file named `wizelake-prod-wizelabs.json` in the files of the keybase team, you need to save it and use it's route as your `GOOGLE_APPLICATION_CREDENTIALS=`. There's a example of it in `.env.example`.
+3. Ask in `#team-wizelabs-io` channel on _Slack_ to join the keybase team to access the `.env (remix)` file with the environment values for `.env`.
 
-3. Edit `prisma/seeds.ts` file and add your user at the very bottom, make sure to replace with your data:
+For the `GOOGLE_APPLICATION_CREDENTIALS=` there will be a file named `wizelake-prod-wizelabs.json` in the files of the keybase team, you need to save it (outside of the project) and use it's absolute path as your `GOOGLE_APPLICATION_CREDENTIALS=`. There's a example of how to do this in `.env.example`.
+
+4. Edit `prisma/seeds.ts` file and add your user at the very bottom, make sure to replace with your data:
 
 ```
   await db.profiles.upsert({
@@ -78,17 +79,24 @@ For the `GOOGLE_APPLICATION_CREDENTIALS=` there will be a file named `wizelake-p
       firstName: "[YOUR_FIRNAME]",
       lastName: "[YOUR_LASTNAME]",
       department: "[YOUR_DEPARTMENT]",
+      preferredName: "[YOUR_PREFERED_NAME]"
     },
   })
 ```
 
-4. (Only dev environment) Set the project's node version with NVM. If you don't have NVM installed read the [documentation](https://github.com/nvm-sh/nvm):
+5. (Only dev environment) Set the project's node version (see "engines" > "node" in "package.json") with NVM. If you don't have NVM installed read the [documentation](https://github.com/nvm-sh/nvm):
 
 ```
-nvm use
+nvm use [NODE VERSION TO USE]
 ```
 
 ## Development
+
+- Install dependencies
+
+  ```sh
+  npm install
+  ```
 
 - Initial database setup:
 

--- a/app/routes/applicants/$applicantId/hold.tsx
+++ b/app/routes/applicants/$applicantId/hold.tsx
@@ -8,9 +8,13 @@ export const action: ActionFunction = async ({ request, params }) => {
     // invariant(params.projectId, "applicantId could not be found");
     const result = await validator.validate(await request.formData());
     const applicantId = parseInt(result.data?.applicantId as string);
-    const projectId = result.data?.project?.id ? result.data?.project.id  : result.data?.projectId;
-    const mentorId = result.data?.mentorId;
     const status = result.data?.status;
+    let projectId = null;
+    let mentorId = null;
+    if (status !== "DRAFT"){ 
+      projectId = result.data?.project?.id ? result.data?.project.id  : result.data?.projectId;
+      mentorId = result.data?.mentorId;
+    } // else reset the values
    try{
        await editApplicant({mentorId, projectId, status}, applicantId);
    } catch (e) {

--- a/app/routes/applicants/$applicantId/index.tsx
+++ b/app/routes/applicants/$applicantId/index.tsx
@@ -210,7 +210,7 @@ if (appliedIdProjects && appliedNameProjects) {
                   </Button>
                 </>
               )}
-              {canEditProject && applicant.status === "HOLD" && (
+              {(canEditProject) && (applicant.status != "DRAFT") && (
                 <Stack direction="column" spacing={1}>
                   <FormControl fullWidth size="medium">
                     <InputLabel id="demo-simple-select-label">
@@ -222,8 +222,8 @@ if (appliedIdProjects && appliedNameProjects) {
                       onChange={changeStatus}
                       value={applicant.status}
                     >
-                      <MenuItem value="HOLD">HOLD</MenuItem>
                       <MenuItem value="DRAFT">DRAFT</MenuItem>
+                      <MenuItem value="HOLD">HOLD</MenuItem>
                       <MenuItem value="ACCEPTED">ACCEPTED</MenuItem>
                       <MenuItem value="REJECTED">REJECTED</MenuItem>
                     </Select>

--- a/app/routes/applicants/$applicantId/index.tsx
+++ b/app/routes/applicants/$applicantId/index.tsx
@@ -153,7 +153,7 @@ if (appliedIdProjects && appliedNameProjects) {
       status: event.target.value
     };
    
-     fetcher.submit(body, { method: "post", action: `/applicants/${applicant.id}/hold`})
+     fetcher.submit(body, { method: "post", action: `/applicants/${applicant.id}/status`})
   }
 
   const searchProfilesDebounced = debounce(searchProfiles, 500);
@@ -341,7 +341,7 @@ if (appliedIdProjects && appliedNameProjects) {
       
       <ModalBox close={handleCloseModal} open={openManageModal}>
         <h2>Select project and mentor</h2>
-        <ValidatedForm validator={validator} method="post" action="./hold" defaultValues={{project: {id: "", name: ""}}}>
+        <ValidatedForm validator={validator} method="post" action="./status" defaultValues={{project: {id: "", name: ""}}}>
           <input type="hidden" name="applicantId" value={applicant.id} />
           <input type="hidden" name="status" value="HOLD" />
 

--- a/app/routes/applicants/$applicantId/status.tsx
+++ b/app/routes/applicants/$applicantId/status.tsx
@@ -23,8 +23,3 @@ export const action: ActionFunction = async ({ request, params }) => {
   
     return redirect(`/applicants/${applicantId}`);
   };
-
-
-export default function holdIntern(){
-
-}

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -588,6 +588,17 @@ async function seed() {
       department: "Engineering"
     },
   });
+  await db.profiles.upsert({
+    where: { email: "beatriz.sanchez@wizeline.com" },
+    update: {},
+    create: {
+      email: "beatriz.sanchez@wizeline.com",
+      firstName: "Beatriz",
+      lastName: "Sanchez",
+      department: "Engineering",
+      preferredName: "Betty",
+    },
+  })
   console.info("Profiles created, starting projects upsert");
 
   const pH = await db.projects.upsert({


### PR DESCRIPTION
# What does this PR do?

Admins and mentors can now revert an applicant status that was Accepted or Rejected back to Hold or Draft.

Also updated README and added personal record to prism as per the Getting Started instructions.

# Where should the reviewer start?

# How should this be manually tested?

As an admin or mentor:
- Choose an applicant that is on Hold and move it to Accepted or Rejected.
- Change its status to Hold or Draft. If changed to Draft the project info and mentor shall be reset in the DB.

As a regular user:
- You shall not be able to view or change the status of any applicant.

# Any background context you want to provide?

Before this PR, admins or mentors could not change the applicant's state once it was Approved or Rejected.

# What are the relevant tickets?

#194 

# Screenshots

As admin and mentor:

https://github.com/wizeline/remix-project-lab/assets/149706555/78bc79ca-5d02-44a9-bbf1-762382254bbb

As regular user:

https://github.com/wizeline/remix-project-lab/assets/149706555/c5d1cfb2-e269-4a18-88e6-3b64de62671c

# Questions

- Shall we rename the `hold.tsx` file to `status.tsx` since now it changes all status and not only sets to hold?

# Checklist

- [x] I added the necessary documentation, if appropriate.
- [ ] I added tests to prove that my fix is effective or my feature works.
- [ ] I reviewed existing Pull Requests before submitting mine.


